### PR TITLE
Support --params, --jobs, local_manifest.xml checkout to subdir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <failsOnError>true</failsOnError>
+          <consoleOutput>true</consoleOutput>
         </configuration>
         <executions>
             <execution>

--- a/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
@@ -164,6 +164,24 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 		this.modifiedFiles = modifiedFiles;
 	}
 
+	/** Converts changelog entry to a string for debugging.
+	 * @return The change log entry information.
+	 */
+	public String toString() {
+		return
+			"path: " + path + "\n"
+			+ "serverPath: " + serverPath + "\n"
+			+ "revision: " + revision + "\n"
+			+ "authorName: " + authorName + "\n"
+			+ "authorEmail: " + authorEmail + "\n"
+			+ "authorDate: " + authorDate + "\n"
+			+ "committerName: " + committerName + "\n"
+			+ "committerEmail: " + committerEmail + "\n"
+			+ "committerDate: " + committerDate + "\n"
+			+ "commitText: " + commitText + "\n"
+			+ "modifiedFiles: " + modifiedFiles + "\n";
+	}
+
 	/**
 	 * Returns the client-side project path.
 	 */

--- a/src/main/java/hudson/plugins/repo/ProjectState.java
+++ b/src/main/java/hudson/plugins/repo/ProjectState.java
@@ -23,6 +23,9 @@
  */
 package hudson.plugins.repo;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * A ProjectState object represents the state of a project. This is used to see
  * when projects have changed. A repo manifest contains a list of projects, and
@@ -33,6 +36,9 @@ public class ProjectState {
 	private final String path;
 	private final String serverPath;
 	private final String revision;
+
+	private static Logger debug =
+		Logger.getLogger("hudson.plugins.repo.ProjectState");
 
 	/**
 	 * Create an object representing the state of a project.
@@ -49,6 +55,9 @@ public class ProjectState {
 		this.path = path;
 		this.serverPath = serverPath;
 		this.revision = revision;
+
+		debug.log(Level.FINE, "path: " + path + " serverPath: " + serverPath
+				+ " revision: " + revision);
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -46,6 +46,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import net.sf.json.JSONObject;
 
@@ -59,11 +61,18 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 public class RepoScm extends SCM {
 
+	private static Logger debug =
+		Logger.getLogger("hudson.plugins.repo.RepoScm");
+
 	private final String manifestRepositoryUrl;
 
 	// Advanced Fields:
 	private final String manifestBranch;
 	private final String repoUrl;
+	private final String mirrorDir;
+	private final String jobs;
+	private final String localManifest;
+	private final String destinationDir;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -81,6 +90,38 @@ public class RepoScm extends SCM {
 	}
 
 	/**
+	 * Returns the name of the mirror directory. By default, this is null and
+	 * repo does not use a mirror.
+	 */
+	public String getMirrorDir() {
+		return mirrorDir;
+	}
+
+	/**
+	 * Returns the number of jobs used for sync. By default, this is null and
+	 * repo does not use concurrent jobs.
+	 */
+	public String getJobs() {
+		return jobs;
+	}
+
+	/**
+	 * Returns the contents of the local_manifest.xml. By default, this is null
+	 * and a local_manifest.xml is neither created nor modified.
+	 */
+	public String getLocalManifest() {
+		return localManifest;
+	}
+
+	/**
+	 * Returns the destination directory. By default, this is null
+	 * and the source synced to the root of the workspace.
+	 */
+	public String getDestinationDir() {
+		return destinationDir;
+	}
+
+	/**
 	 * The constructor takes in user parameters and sets them. Each job using
 	 * the RepoSCM will call this constructor.
 	 *
@@ -90,12 +131,37 @@ public class RepoScm extends SCM {
 	 *            The branch of the manifest repository. Typically this is null
 	 *            or the empty string, which will cause repo to default to
 	 *            "master".
+	 * @param mirrorDir
+	 *            The path of the mirror directory to reference when
+	 *            initialising repo.
+	 * @param jobs
+	 *            The number of concurrent jobs to use for the sync command. If
+	 *            this is null the jobs parameter is not specified.
+	 * @param localManifest
+	 *            If not null this string is written to .repo/local_manifest.xml
+	 * @param destinationDir
+	 *            If not null then the source is synced to the destinationDir
+	 *            subdirectory of the workspace.
 	 */
 	@DataBoundConstructor
 	public RepoScm(final String manifestRepositoryUrl,
-			final String manifestBranch) {
+			final String manifestBranch, final String mirrorDir,
+			final String jobs, final String localManifest,
+			final String destinationDir) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
+		this.mirrorDir = Util.fixEmptyAndTrim(mirrorDir);
+		this.jobs = Util.fixEmptyAndTrim(jobs);
+		this.localManifest = Util.fixEmptyAndTrim(localManifest);
+		this.destinationDir = Util.fixEmptyAndTrim(destinationDir);
+
+		debug.log(Level.CONFIG, ""
+				+ "manifestRepositoryUrl: " + manifestRepositoryUrl + "\n"
+				+ "manifestBranch: " + manifestBranch + "\n"
+				+ "mirrorDir: " + mirrorDir + "\n"
+				+ "jobs: " + jobs + "\n"
+				+ "localManifest: " + localManifest + "\n"
+				+ "destinationDir: " + destinationDir);
 		// TODO: repoUrl
 		this.repoUrl = null;
 	}
@@ -126,13 +192,26 @@ public class RepoScm extends SCM {
 				return PollingResult.BUILD_NOW;
 			}
 		}
-		if (!checkoutCode(launcher, workspace, listener.getLogger())) {
+
+		FilePath repoDir;
+		if (destinationDir != null) {
+			repoDir = workspace.child(destinationDir);
+			if (!repoDir.isDirectory()) {
+				repoDir.mkdirs();
+				debug.log(Level.FINE, "mkdir " + destinationDir);
+			}
+		} else {
+			repoDir = workspace.child("");
+		}
+
+		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
 			// Some error occurred, try a build now so it gets logged.
 			return new PollingResult(myBaseline, myBaseline,
 					Change.INCOMPARABLE);
 		}
+
 		final RevisionState currentState =
-				new RevisionState(getStaticManifest(launcher, workspace,
+				new RevisionState(getStaticManifest(launcher, repoDir,
 						listener.getLogger()), manifestBranch,
 						listener.getLogger());
 		final Change change;
@@ -150,19 +229,32 @@ public class RepoScm extends SCM {
 			final Launcher launcher, final FilePath workspace,
 			final BuildListener listener, final File changelogFile)
 			throws IOException, InterruptedException {
-		if (!checkoutCode(launcher, workspace, listener.getLogger())) {
+
+		FilePath repoDir;
+		if (destinationDir != null) {
+			repoDir = workspace.child(destinationDir);
+			if (!repoDir.isDirectory()) {
+				repoDir.mkdirs();
+				debug.log(Level.FINE, "mkdir " + destinationDir);
+			}
+		} else {
+			repoDir = workspace.child("");
+		}
+
+		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
 			return false;
 		}
 		final String manifest =
-				getStaticManifest(launcher, workspace, listener.getLogger());
+				getStaticManifest(launcher, repoDir, listener.getLogger());
 		final RevisionState currentState =
 				new RevisionState(manifest, manifestBranch,
 						listener.getLogger());
 		build.addAction(currentState);
 		final RevisionState previousState =
 				getLastState(build.getPreviousBuild());
+
 		ChangeLog.saveChangeLog(currentState, previousState,
-				changelogFile, launcher, workspace);
+				changelogFile, launcher, repoDir, listener.getLogger());
 		build.addAction(new TagAction(build));
 		return true;
 	}
@@ -171,6 +263,20 @@ public class RepoScm extends SCM {
 			final FilePath workspace, final OutputStream logger)
 			throws IOException, InterruptedException {
 		final List<String> commands = new ArrayList<String>(4);
+
+		debug.log(Level.INFO, "Checking out code in : " + workspace.getName());
+
+		/* Always delete local manifest before calling init to remove corrupt
+		 * local_manifest.xml files.
+		 */
+		FilePath rdir = workspace.child(".repo");
+		if (rdir != null) {
+			FilePath lm = rdir.child("local_manifest.xml");
+			if (lm.delete()) {
+				debug.log(Level.FINEST, "Removed old local_manifest.xml");
+			}
+		}
+
 		commands.add(getDescriptor().getExecutable());
 		commands.add("init");
 		commands.add("-u");
@@ -178,6 +284,9 @@ public class RepoScm extends SCM {
 		if (manifestBranch != null) {
 			commands.add("-b");
 			commands.add(manifestBranch);
+		}
+		if (mirrorDir != null) {
+			commands.add("--reference=" + mirrorDir);
 		}
 		if (repoUrl != null) {
 			commands.add("--repo-url=" + repoUrl);
@@ -189,10 +298,23 @@ public class RepoScm extends SCM {
 		if (returnCode != 0) {
 			return false;
 		}
+
+		if (rdir != null) {
+			FilePath lm = rdir.child("local_manifest.xml");
+			if (localManifest != null && localManifest.length() > 0) {
+				debug.log(Level.CONFIG, "Creating local_manifest.xml");
+				lm.write(localManifest, null);
+				debug.log(Level.FINEST, localManifest);
+			}
+		}
+
 		commands.clear();
 		commands.add(getDescriptor().getExecutable());
 		commands.add("sync");
 		commands.add("-d");
+		if (jobs != null)  {
+			commands.add("--jobs=" + jobs);
+		}
 		returnCode =
 				launcher.launch().stdout(logger).pwd(workspace)
 						.cmds(commands).join();
@@ -216,6 +338,7 @@ public class RepoScm extends SCM {
         launcher.launch().stderr(logger).stdout(output).pwd(workspace).
             cmds(commands).join();
         final String manifestText = output.toString();
+		debug.log(Level.FINEST, manifestText);
 		return manifestText;
 	}
 

--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -54,6 +56,9 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 	private final Map<String, ProjectState> projects =
 			new TreeMap<String, ProjectState>();
 	private final String branch;
+
+	private static Logger debug =
+		Logger.getLogger("hudson.plugins.repo.RevisionState");
 
 	/**
 	 * Creates a new RepoRevisionState.
@@ -175,6 +180,7 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 			// Everything is new. The change log would include every change,
 			// which might be a little unwieldy (and take forever to
 			// generate/parse). Instead, we will return null (no changes)
+			debug.log(Level.FINE, "Everything is new");
 			return null;
 		}
 		final Set<String> keys = projects.keySet();
@@ -185,6 +191,7 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 			if (status == null) {
 				// This is a new project, just added to the manifest.
 				final ProjectState newProject = projects.get(key);
+				debug.log(Level.FINE, "New project: " + key);
 				changes.add(new ProjectState(newProject.getPath(), newProject
 						.getServerPath(), null));
 			} else if (!status.equals(projects.get(key))) {

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -16,5 +16,21 @@
 			<f:textbox name="repo.manifestBranch" value="${scm.manifestBranch}"/>
 		</f:entry>
 
+		<f:entry title="Destination Directory" help="/plugin/repo/help-destinationDir.html">
+			<f:textbox name="repo.destinationDir" value="${scm.destinationDir}"/>
+		</f:entry>
+
+		<f:entry title="Mirror Directory" help="/plugin/repo/help-mirrorDir.html">
+			<f:textbox name="repo.mirrorDir" value="${scm.mirrorDir}"/>
+		</f:entry>
+
+		<f:entry title="Jobs" help="/plugin/repo/help-jobs.html">
+			<f:textbox name="repo.jobs" value="${scm.jobs}"/>
+		</f:entry>
+
+		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">
+			<f:textarea name="repo.localManifest" value="${scm.localManifest}" rows="10" />
+		</f:entry>
+
 	</f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-desintationDir.html
+++ b/src/main/webapp/help-desintationDir.html
@@ -1,0 +1,6 @@
+
+<div>
+   <p>
+   The sub-directory of the workspace where the source should be synced. The default is the root of the workspace.
+  </p>
+</div>

--- a/src/main/webapp/help-jobs.html
+++ b/src/main/webapp/help-jobs.html
@@ -1,0 +1,5 @@
+<div>
+   <p>
+   Specify the number of jobs to execute in parallel when syncing the code. Default is 1.
+  </p>
+</div>

--- a/src/main/webapp/help-localManifest.xml
+++ b/src/main/webapp/help-localManifest.xml
@@ -1,0 +1,6 @@
+
+<div>
+  <p>
+     Optionally, specify the contents of .repo/local_manifest.xml. This is written prior to callinging sync.  
+  </p>
+</div>

--- a/src/main/webapp/help-mirrorDir.html
+++ b/src/main/webapp/help-mirrorDir.html
@@ -1,0 +1,5 @@
+<div>
+   <p>
+   Optionally, specify the location of the mirror directory to reference when initialising this repository.
+  </p>
+</div>


### PR DESCRIPTION
Add advanced options for:

The path of the mirror directory to use.
The --jobs parameter
Syncing the repo to a subdirectory of the workspace
Creating a local_manifest.xml so allowing individual git repositories to
be added or removed.

Also:
java.util.logging added to diagnose hard to reproduce problems
If localManifest parameter is not specified then local_manfifest.xml is
deleted. This is implemented by always deleting the local_manifest.xml
then deleting it to fix broken (e.g. zero length) local_manifest.xml
files.
