### PR TITLE
Fixed NPE in RevisionState.hashCode()

### DIFF
--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -136,7 +136,9 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return branch.hashCode() ^ manifest.hashCode() ^ projects.hashCode();
+		return (branch != null ? branch.hashCode() : 0)
+			^ (manifest != null ? manifest.hashCode() : 0)
+			^ projects.hashCode();
 	}
 
 	/**


### PR DESCRIPTION
Whenever we were restarting Jenkins every build using repo scm would disappear.
This was caused by a NPE in RevisionState.hashCode() causing Jenkins to stop loading the build.

This patch fixes the NPE.
