### PR TITLE
Add feature: support two repo sync's options

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -42,7 +42,9 @@ Checkstyle configuration that checks coding conventions.
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
     <module name="MethodLength"/>
-    <module name="ParameterNumber"/>
+    <module name="ParameterNumber">
+      <property name="max" value="10"/>
+    </module>
     <module name="LineLength">
       <property name="tabWidth" value="4"/>
     </module>

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -74,6 +74,8 @@ public class RepoScm extends SCM {
 	private final int jobs;
 	private final String localManifest;
 	private final String destinationDir;
+	private final boolean currentBranch;
+	private final boolean quiet;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -131,6 +133,19 @@ public class RepoScm extends SCM {
 	}
 
 	/**
+	 * Returns the value of currentBranch.
+    */
+	public boolean isCurrentBranch() {
+		return currentBranch;
+	}
+
+    /**
+	 * Returns the value of quiet.
+    */
+	public boolean isQuiet() {
+		return quiet;
+	}
+	/**
 	 * The constructor takes in user parameters and sets them. Each job using
 	 * the RepoSCM will call this constructor.
 	 *
@@ -154,12 +169,19 @@ public class RepoScm extends SCM {
 	 * @param destinationDir
 	 *            If not null then the source is synced to the destinationDir
 	 *            subdirectory of the workspace.
+	 * @param currentBranch
+	 * 			  if this value is true,
+	 *            add "-c" options when excute "repo sync".
+	 * @param quiet
+	 * 			  if this value is true,
+	 *            add "-q" options when excute "repo sync".
 	 */
 	@DataBoundConstructor
 	public RepoScm(final String manifestRepositoryUrl,
 			final String manifestBranch, final String manifestFile,
 			final String mirrorDir, final int jobs,
-			final String localManifest, final String destinationDir) {
+			final String localManifest, final String destinationDir,
+			final boolean currentBranch, final boolean quiet) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
 		this.manifestFile = Util.fixEmptyAndTrim(manifestFile);
@@ -167,6 +189,8 @@ public class RepoScm extends SCM {
 		this.jobs = jobs;
 		this.localManifest = Util.fixEmptyAndTrim(localManifest);
 		this.destinationDir = Util.fixEmptyAndTrim(destinationDir);
+		this.currentBranch = currentBranch;
+		this.quiet = quiet;
 		// TODO: repoUrl
 		this.repoUrl = null;
 	}
@@ -271,6 +295,12 @@ public class RepoScm extends SCM {
 		commands.add(getDescriptor().getExecutable());
 		commands.add("sync");
 		commands.add("-d");
+		if (isCurrentBranch()) {
+			commands.add("-c");
+		}
+        if (isQuiet()) {
+            commands.add("-q");
+        }
 		if (jobs > 0) {
 			commands.add("--jobs=" + jobs);
 		}

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -32,6 +32,16 @@
 			<f:textbox name="repo.jobs" value="${scm.jobs}" clazz="number"/>
 		</f:entry>
 
+		<f:entry title="Current Branch" help="/plugin/repo/help-currentBranch.html">
+			<f:checkbox name="repo.currentBranch"
+			   checked="${h.defaultToTrue(scm.currentBranch)}" />
+		</f:entry>
+
+		<f:entry title="Quiet" help="/plugin/repo/help-quiet.html">
+			<f:checkbox name="repo.quiet"
+			   checked="${h.defaultToTrue(scm.quiet)}" />
+		</f:entry>
+
 		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">
 			<f:textarea name="repo.localManifest" value="${scm.localManifest}" rows="10" />
 		</f:entry>

--- a/src/main/webapp/help-currentBranch.html
+++ b/src/main/webapp/help-currentBranch.html
@@ -1,0 +1,8 @@
+<div>
+   <p>
+   If this option value is checked, added repo sync '-c' option.
+   This option is fetched only current branch from server.
+   So sync operation is more faster than operation without this option
+   This is passed to repo as <code>repo sync <i>-c</i></code>.
+  </p>
+</div>

--- a/src/main/webapp/help-quiet.html
+++ b/src/main/webapp/help-quiet.html
@@ -1,0 +1,8 @@
+<div>
+   <p>
+   If this option value is checked, added repo sync '-q' option.
+   This option is be more quiet. you can't see tag and branch information
+   So log file is more smaller than orignal log file
+   This is passed to repo as <code>repo sync <i>-q</i></code>.
+  </p>
+</div>


### PR DESCRIPTION
- current branch option(-c) is fetch only current branch from server
  if this option is enabled, sync operation will be more faster
- quiet option(-q) is more quiet. you can't see tag and branch information
  if this option is enabled, log file will be more smaller
