### PR TITLE
Fix UnsupportedOperationException when another plugin calls getAffectedFiles()

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
@@ -260,6 +260,15 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 		return modifiedFiles;
 	}
 
+	/**
+	 * Returns a set of paths in the workspace that was
+	 * affected by this change.
+	 */
+	@Override
+	public List<ModifiedFile> getAffectedFiles() {
+		return modifiedFiles;
+	}
+
 	@Override
 	public String getMsg() {
 		return getCommitText();


### PR DESCRIPTION
When the `getAffectedFiles()` method is called, it is handled by the parent (`ChangeLogSet.Entry#getAffectedFiles()`), which simply throws `UnsupportedOperationException`:

```
[project] $ git log --raw --first-parent --format="zzREPOzz%H%n%an<%ae>%aD%n%cn<%ce>%cD%n%s%n%n%byyREPOyy" 22f7f44bb2a5c659724524dfecdd98ed2b0959dd..c598ef751d842b23dc75e5b42855be3bb60a9f3d
FATAL: getAffectedFiles() is not implemented by repo
java.lang.UnsupportedOperationException: getAffectedFiles() is not implemented by repo
    at hudson.scm.ChangeLogSet$Entry.getAffectedFiles(ChangeLogSet.java:201)
    at jenkins.plugins.hipchat.ActiveNotifier.getChanges(ActiveNotifier.java:78)
    at jenkins.plugins.hipchat.ActiveNotifier.started(ActiveNotifier.java:41)
    at jenkins.plugins.hipchat.HipChatNotifier$HipChatJobProperty.prebuild(HipChatNotifier.java:170)
    at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:748)
    at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:743)
    at hudson.model.AbstractBuild$AbstractBuildExecution.preBuild(AbstractBuild.java:739)
    at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:496)
    at hudson.model.Run.execute(Run.java:1502)
    at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
    at hudson.model.ResourceController.execute(ResourceController.java:88)
    at hudson.model.Executor.run(Executor.java:236)
```

Another method, `getModifiedFiles()` was already defined in the `ChangeLogEntry` class, but that does not match with the parent's interface.  This overrides the parent method and does the same thing as `getModifiedFiles()`, in order to satisfy the interface.
