### PR TITLE
Allow localManifest to be specified either literally or as an URL

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -151,10 +151,10 @@ public class RepoScm extends SCM {
 	 *            The number of concurrent jobs to use for the sync command. If
 	 *            this is 0 or negative the jobs parameter is not specified.
 	 * @param localManifest
-	 *	      May be null, a string containing XML, or an URL.
-	 *	      If XML, this string is written to .repo/local_manifest.xml
-	 *	      If an URL, the URL is fetched and the content is written
-	 *	      to .repo/local_manifest.xml
+	 *            May be null, a string containing XML, or an URL.
+	 *            If XML, this string is written to .repo/local_manifest.xml
+	 *            If an URL, the URL is fetched and the content is written
+	 *            to .repo/local_manifest.xml
 	 * @param destinationDir
 	 *            If not null then the source is synced to the destinationDir
 	 *            subdirectory of the workspace.

--- a/src/main/webapp/help-localManifest.html
+++ b/src/main/webapp/help-localManifest.html
@@ -1,18 +1,19 @@
 <div>
   <p>
-     The contents of .repo/local_manifest.xml. This is written prior to
-callinging sync. The default is to not use a local_manifest file.
+     The contents of <code>.repo/local_manifest.xml</code>. This is written prior to
+callinging sync. The default is to not use a <code>local_manifest.txt</code> file.
   </p>
-  <p>The may be given here literally, as XML; see the example below.
+  <p>The contents may be given here literally, as XML; see the example below.
 Such literal content <b>must</b> start with the
 string <code>&lt;?xml</code>.  Alternatively, the content may be given
-as an URL, in which case the file pointed by the URL is user.  If the
-content does not start with the code&lt;?xml</code> prefix, it is
+as an URL, in which case the file pointed by the URL is used.  If the
+content does not start with the <code>&lt;?xml</code> prefix, it is
 assumed to be an URL.</p>
+<p><b>An example</b></p>
   <pre>
     &lt;?xml version="1.0" encoding="UTF-8"?&gt;
     &lt;manifest&gt;
-      &lt;project path="external/project" name="org/project" remote="github" revision="master" /&/gt;
+      &lt;project path="external/project" name="org/project" remote="github" revision="master" /&gt;
     &lt;/manifest&gt;
   </pre>
 </div>


### PR DESCRIPTION
Check the beginning of the localManifest field.  If it starts with
legal XML preamble <?xml then use it literally.  Otherwise assume
it is an URL, and fetch the URL.
