### PR TITLE
Allow using parameters (environment variables) in Repo plugin input fields.

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -27,6 +27,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
+import hudson.EnvVars;
 import hudson.model.BuildListener;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
@@ -77,6 +78,8 @@ public class RepoScm extends SCM {
 	private final String destinationDir;
 	private final boolean currentBranch;
 	private final boolean quiet;
+	private final boolean supportsPolling;
+	private final boolean supportsParameters;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -148,6 +151,20 @@ public class RepoScm extends SCM {
 	}
 
 	/**
+	 * Returns true if polling support is enabled.	By default, it is not.
+	 */
+	public boolean getPollingEnabled() {
+		return supportsPolling;
+	}
+
+	/**
+	 * Returns true if parameters support is enabled.  By default, it is not.
+	 */
+	public boolean getParametersEnabled() {
+		return supportsParameters;
+	}
+
+	/**
 	 * The constructor takes in user parameters and sets them. Each job using
 	 * the RepoSCM will call this constructor.
 	 *
@@ -180,13 +197,17 @@ public class RepoScm extends SCM {
 	 * @param quiet
 	 * 			  if this value is true,
 	 *            add "-q" options when excute "repo sync".
+	 * @param behaviour
+	 *            The desired behaviour, "polling", "parameters", or "neither".
 	 */
+	//CS IGNORE ParameterNumberCheck FOR NEXT 6 LINES. REASON: It makes sense to have more parameters here
 	@DataBoundConstructor
 	public RepoScm(final String manifestRepositoryUrl,
 			final String manifestBranch, final String manifestFile,
 			final String mirrorDir, final int jobs,
 			final String localManifest, final String destinationDir,
-			final boolean currentBranch, final boolean quiet) {
+			final boolean currentBranch, final boolean quiet,
+			final String behaviour) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
 		this.manifestFile = Util.fixEmptyAndTrim(manifestFile);
@@ -196,6 +217,16 @@ public class RepoScm extends SCM {
 		this.destinationDir = Util.fixEmptyAndTrim(destinationDir);
 		this.currentBranch = currentBranch;
 		this.quiet = quiet;
+		if (behaviour.equals("polling")) {
+			this.supportsPolling = true;
+			this.supportsParameters = false;
+		} else if (behaviour.equals("parameters")) {
+			this.supportsPolling = false;
+			this.supportsParameters = true;
+		} else {
+			this.supportsPolling = false;
+			this.supportsParameters = false;
+		}
 		// TODO: repoUrl
 		this.repoUrl = null;
 	}
@@ -224,6 +255,9 @@ public class RepoScm extends SCM {
 			final AbstractBuild<?, ?> build, final Launcher launcher,
 			final TaskListener listener) throws IOException,
 			InterruptedException {
+		if (!getPollingEnabled()) {
+			throw new InterruptedException("Polling mode not enabled.");
+		}
 		// We add our SCMRevisionState from within checkout, so this shouldn't
 		// be called often. However it will be called if this is the first
 		// build, if a build was aborted before it reported the repository
@@ -237,6 +271,9 @@ public class RepoScm extends SCM {
 			final FilePath workspace, final TaskListener listener,
 			final SCMRevisionState baseline) throws IOException,
 			InterruptedException {
+		if (!getPollingEnabled()) {
+			throw new InterruptedException("Polling mode not enabled.");
+		}
 		SCMRevisionState myBaseline = baseline;
 		if (myBaseline == null) {
 			// Probably the first build, or possibly an aborted build.
@@ -248,7 +285,7 @@ public class RepoScm extends SCM {
 
 		final FilePath repoDir = getRepoDir(workspace);
 
-		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
+		if (!checkoutCode(launcher, repoDir, listener.getLogger(), null)) {
 			// Some error occurred, try a build now so it gets logged.
 			return new PollingResult(myBaseline, myBaseline,
 					Change.INCOMPARABLE);
@@ -276,7 +313,8 @@ public class RepoScm extends SCM {
 
 		FilePath repoDir = getRepoDir(workspace);
 
-		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
+		if (!checkoutCode(launcher, repoDir, listener.getLogger(),
+		                  build.getEnvironment(listener))) {
 			return false;
 		}
 		final String manifest =
@@ -318,8 +356,17 @@ public class RepoScm extends SCM {
 		return returnCode;
 	}
 
+	private String expand(final EnvVars env, final String string) {
+		if (getParametersEnabled()) {
+			return env.expand(string);
+		} else {
+			return string;
+		}
+	}
+
 	private boolean checkoutCode(final Launcher launcher,
-			final FilePath workspace, final OutputStream logger)
+			final FilePath workspace, final OutputStream logger,
+			final EnvVars env)
 			throws IOException, InterruptedException {
 		final List<String> commands = new ArrayList<String>(4);
 
@@ -328,20 +375,20 @@ public class RepoScm extends SCM {
 		commands.add(getDescriptor().getExecutable());
 		commands.add("init");
 		commands.add("-u");
-		commands.add(manifestRepositoryUrl);
+		commands.add(expand(env, manifestRepositoryUrl));
 		if (manifestBranch != null) {
 			commands.add("-b");
-			commands.add(manifestBranch);
+			commands.add(expand(env, manifestBranch));
 		}
 		if (manifestFile != null) {
 			commands.add("-m");
-			commands.add(manifestFile);
+			commands.add(expand(env, manifestFile));
 		}
 		if (mirrorDir != null) {
-			commands.add("--reference=" + mirrorDir);
+			commands.add("--reference=" + expand(env, mirrorDir));
 		}
 		if (repoUrl != null) {
-			commands.add("--repo-url=" + repoUrl);
+			commands.add("--repo-url=" + expand(env, repoUrl));
 			commands.add("--no-repo-verify");
 		}
 		int returnCode =
@@ -355,10 +402,11 @@ public class RepoScm extends SCM {
 			FilePath lm = rdir.child("local_manifest.xml");
 			lm.delete();
 			if (localManifest != null) {
-				if (localManifest.startsWith("<?xml")) {
-					lm.write(localManifest, null);
+				final String lmContent = expand(env, localManifest);
+				if (lmContent.startsWith("<?xml")) {
+					lm.write(lmContent, null);
 				} else {
-					URL url = new URL(localManifest);
+					URL url = new URL(lmContent);
 					lm.copyFrom(url);
 				}
 			}

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -200,6 +200,25 @@ public class RepoScm extends SCM {
 		this.repoUrl = null;
 	}
 
+	private FilePath getRepoDir(final FilePath workspace)
+		throws IOException, InterruptedException {
+		if (workspace == null) {
+			throw new IOException("getRepoDir: no workspace defined");
+		}
+
+		final FilePath repoDir;
+		if (destinationDir != null) {
+			repoDir = workspace.child(destinationDir);
+			if (!repoDir.isDirectory()) {
+				repoDir.mkdirs();
+			}
+		} else {
+			repoDir = workspace;
+		}
+		return repoDir;
+	}
+
+
 	@Override
 	public SCMRevisionState calcRevisionsFromBuild(
 			final AbstractBuild<?, ?> build, final Launcher launcher,
@@ -227,15 +246,7 @@ public class RepoScm extends SCM {
 			}
 		}
 
-		FilePath repoDir;
-		if (destinationDir != null) {
-			repoDir = workspace.child(destinationDir);
-			if (!repoDir.isDirectory()) {
-				repoDir.mkdirs();
-			}
-		} else {
-			repoDir = workspace;
-		}
+		final FilePath repoDir = getRepoDir(workspace);
 
 		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
 			// Some error occurred, try a build now so it gets logged.
@@ -263,15 +274,7 @@ public class RepoScm extends SCM {
 			final BuildListener listener, final File changelogFile)
 			throws IOException, InterruptedException {
 
-		FilePath repoDir;
-		if (destinationDir != null) {
-			repoDir = workspace.child(destinationDir);
-			if (!repoDir.isDirectory()) {
-				repoDir.mkdirs();
-			}
-		} else {
-			repoDir = workspace;
-		}
+		FilePath repoDir = getRepoDir(workspace);
 
 		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
 			return false;

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -46,5 +46,19 @@
 			<f:textarea name="repo.localManifest" value="${scm.localManifest}" rows="10" />
 		</f:entry>
 
+		<f:entry title="Polling and parametrization" help="/plugin/repo/help-pollingAndParameters.html">
+			<f:radio name="repo.behaviour" value="polling"
+			         checked="${scm.pollingEnabled}" id="behaviour.polling"/>
+			<label for="behaviour.polling">Enable polling</label>
+			<st:nbsp />
+			<f:radio name="repo.behaviour" value="parameters"
+			         checked="${scm.parametersEnabled}" id="behaviour.parameters"/>
+			<label for="behaviour.parameters">Enable parameters</label>
+			<st:nbsp />
+			<f:radio name="repo.behaviour" value="neither"
+			         checked="${!scm.parametersEnabled and !scm.pollingEnabled}" id="behaviour.neither" />
+			<label for="behaviour.neither">Disable both</label>
+		</f:entry>
+
 	</f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-pollingAndParameters.html
+++ b/src/main/webapp/help-pollingAndParameters.html
@@ -1,0 +1,17 @@
+<div>
+  <p>Control polling and parametrization support.  By default both are disabled.</p>
+  <p>When polling is enabled, you can enable the Jenkins SCM polling
+     option to make Jenkins to periodically check against changes in
+     the repo.  This is a relatively expensive operation, though.
+  <p>When parameters are enabled, parameters and other environment
+     variables can be used when defining the repository url, branch,
+     manifest file, mirror directory, jobs, and local manifest.
+     The parameters can be used anywhere within the text, so that you
+     can e.g. construct the <code>local_manifest.xml</code> content
+     from several bits and pieces.</p>
+  <p>Please note that polling and parametrizing are incompatible at
+     the moment.  If you enable parameters, then any attempt to use
+     polling will cause a run time error, and if you enable polling,
+     then any environment variables in the input fields will be
+     taken literally and not expanded.</p>
+</div>


### PR DESCRIPTION
Adds support for expanding environment variables in input fields.

As SCM polling and SCM parametrisation seem to be incompatible
at the Jenkins core level at the moment, forces polling off if
parametrisation is enabled, and vice versa.

Adds a configuration option for enabling parametrisation,
SCM polling, or disabling both.  Defaults to both disabled.
