### PR TITLE
partial fix for [JENKINS-17913] expand variables for branch, added support...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version><!-- which version of Hudson is this plugin built against? -->
+    <version>1.466</version><!-- which version of Hudson is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,138 +1,151 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.525</version><!-- which version of Hudson is this plugin built against? -->
-  </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>1.525</version><!-- which version of Hudson is this plugin built 
+			against? -->
+	</parent>
 
-  <groupId>org.jenkins-ci.plugins</groupId>
-  <artifactId>repo</artifactId>
-  <version>1.6-SNAPSHOT</version>
-  <packaging>hpi</packaging>
-  <name>Jenkins REPO plugin</name>
-  <description>Integrates Jenkins with REPO SCM</description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Repo+Plugin</url>
+	<groupId>org.jenkins-ci.plugins</groupId>
+	<artifactId>repo</artifactId>
+	<version>1.6-SNAPSHOT</version>
+	<packaging>hpi</packaging>
+	<name>Jenkins REPO plugin</name>
+	<description>Integrates Jenkins with REPO SCM</description>
+	<url>http://wiki.jenkins-ci.org/display/JENKINS/Repo+Plugin</url>
 
-  <licenses>
-    <license>
-      <name>MIT</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
-      <comments>Copyright 2011 Brad Larson. All rights reserved.</comments>
-    </license>
-  </licenses>
+	<licenses>
+		<license>
+			<name>MIT</name>
+			<url>http://www.opensource.org/licenses/mit-license.php</url>
+			<comments>Copyright 2011 Brad Larson. All rights reserved.</comments>
+		</license>
+	</licenses>
 
-  <developers>
-    <developer>
-      <id>aep</id>
-      <name>Arvid E. Picciani</name>
-      <email>aep-jenkins@exys.org</email>
-      <roles>
-        <role>developer</role>
-        <role>maintainer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>bjarkef</id>
-      <name>Bjarke Freund-Hansen</name>
-      <email>bjarkefh@gmail.com</email>
-      <roles>
-        <role>developer</role>
-        <role>maintainer</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>bklarson</id>
-      <name>Brad Larson</name>
-      <email>bklarson@gmail.com</email>
-      <roles>
-        <role>developer</role>
-        <role>maintainer</role>
-      </roles>
-      <timezone>-6</timezone>
-    </developer>
-  </developers>
+	<developers>
+		<developer>
+			<id>aep</id>
+			<name>Arvid E. Picciani</name>
+			<email>aep-jenkins@exys.org</email>
+			<roles>
+				<role>developer</role>
+				<role>maintainer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>bjarkef</id>
+			<name>Bjarke Freund-Hansen</name>
+			<email>bjarkefh@gmail.com</email>
+			<roles>
+				<role>developer</role>
+				<role>maintainer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>bklarson</id>
+			<name>Brad Larson</name>
+			<email>bklarson@gmail.com</email>
+			<roles>
+				<role>developer</role>
+				<role>maintainer</role>
+			</roles>
+			<timezone>-6</timezone>
+		</developer>
+	</developers>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <goals>deploy</goals>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.10</version>
-        <configuration>
-          <configLocation>checkstyle.xml</configLocation>
-          <failsOnError>true</failsOnError>
-          <consoleOutput>true</consoleOutput>
-        </configuration>
-        <executions>
-            <execution>
-                <goals><goal>check</goal></goals>
-                <phase>compile</phase>
-            </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jenkins-ci.tools</groupId>
+				<artifactId>maven-hpi-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<disabledTestInjection>true</disabledTestInjection>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<configuration>
+					<goals>deploy</goals>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<configLocation>checkstyle.xml</configLocation>
+					<failsOnError>true</failsOnError>
+					<consoleOutput>true</consoleOutput>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<phase>compile</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jxr-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</reporting>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.8.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
+	</properties>
 
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
-  
-  <scm>
-    <connection>scm:git:git://github.com/jenkinsci/repo-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/repo-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/repo-plugin</url>
-  </scm>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<distributionManagement>
+		<repository>
+			<id>maven.jenkins-ci.org</id>
+			<url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
+		</repository>
+	</distributionManagement>
+
+	<scm>
+		<connection>scm:git:git://github.com/jenkinsci/repo-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/repo-plugin.git</developerConnection>
+		<url>http://github.com/jenkinsci/repo-plugin</url>
+	</scm>
 
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
 </project>  
   
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Hudson is this plugin built against? -->
+    <version>1.525</version><!-- which version of Hudson is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -57,30 +57,6 @@
 
   <build>
     <plugins>
-      <plugin>
-          <groupId>org.jenkins-ci.tools</groupId>
-          <artifactId>maven-hpi-plugin</artifactId>
-          <version>1.96</version>
-          <extensions>true</extensions>
-          <executions>
-            <execution>
-            	<id>default</id>
-                <phase>default</phase>
-            </execution>
-            <execution>
-                <id>package</id>
-                <phase>package</phase>
-            </execution>
-            <execution>
-                <id>generate-test-sources</id>
-                <phase>generate-test-sources</phase>
-            </execution>
-            <execution>
-                <id>validate</id>
-                <phase>validate</phase>
-            </execution>
-          </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
   <build>
     <plugins>
       <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <version>1.96</version>
+          <extensions>true</extensions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
             <execution>
                 <phase>default</phase>
             </execution>
+            <execution>
+                <phase>package</phase>
+            </execution>
+            <execution>
+                <phase>generate-test-sources</phase>
+            </execution>
+            <execution>
+                <phase>validate</phase>
+            </execution>
           </executions>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,15 +64,19 @@
           <extensions>true</extensions>
           <executions>
             <execution>
+            	<id>default</id>
                 <phase>default</phase>
             </execution>
             <execution>
+                <id>package</id>
                 <phase>package</phase>
             </execution>
             <execution>
+                <id>generate-test-sources</id>
                 <phase>generate-test-sources</phase>
             </execution>
             <execution>
+                <id>validate</id>
                 <phase>validate</phase>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
           <artifactId>maven-hpi-plugin</artifactId>
           <version>1.96</version>
           <extensions>true</extensions>
+          <executions>
+            <execution>
+                <phase>default</phase>
+            </execution>
+          </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.6</version>
+        <version>2.10</version>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <failsOnError>true</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.10</version>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
           <failsOnError>true</failsOnError>

--- a/src/main/java/hudson/plugins/repo/EnvVarUtils.java
+++ b/src/main/java/hudson/plugins/repo/EnvVarUtils.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, Brad Larson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.repo;
+
+/**
+ * Utilities for dealing with environment variables.
+ * @author Rainer Burgstaller
+ */
+public final class EnvVarUtils {
+	/**
+	 * Prevent construction.
+	 */
+	private EnvVarUtils() {
+	}
+
+	/**
+	 * Converts any given string into a valid environment var name.
+	 * @param text	the text to convert
+	 * @return a valid variable name
+	 */
+	public static String convertToEnvVariableName(final String text) {
+		final String validRegex = "[a-zA-Z_]+[a-zA-Z0-9_]*";
+		// quick bail out
+		if (text.matches(validRegex)) {
+			return text;
+		}
+		return text.toUpperCase().replaceAll("[^a-zA-Z0-9_]", "_");
+	}
+}

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.repo;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -34,10 +35,10 @@ import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
-import hudson.scm.SCM;
+import hudson.scm.PollingResult.Change;
 import hudson.scm.SCMDescriptor;
 import hudson.scm.SCMRevisionState;
-import hudson.scm.PollingResult.Change;
+import hudson.scm.SCM;
 import hudson.util.FormValidation;
 
 import java.io.ByteArrayOutputStream;
@@ -47,6 +48,8 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -78,6 +81,7 @@ public class RepoScm extends SCM {
 	private final String destinationDir;
 	private final boolean currentBranch;
 	private final boolean quiet;
+	private final boolean exportRevisions;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -164,6 +168,15 @@ public class RepoScm extends SCM {
 	}
 
 	/**
+	 * Returns the value of the revision export flag.
+	 * @return if <code>true</code> then the project revisions will be
+	 * 	published as environment variables.
+	 */
+	public boolean isExportRevisions() {
+		return exportRevisions;
+	}
+
+	/**
 	 * The constructor takes in user parameters and sets them. Each job using
 	 * the RepoSCM will call this constructor.
 	 *
@@ -203,6 +216,12 @@ public class RepoScm extends SCM {
 	 * @param quiet
 	 * 			  if this value is true,
 	 *            add "-q" options when excute "repo sync".
+	 * @param exportRevisions
+	 * 			  if <code>true</code> then the build will set environment
+	 * 		      variables for each project in the repo. The project name
+	 *            will be used as the key and the value will be set to the
+	 *            revision number of the project. The project name will be
+	 *            converted to a valid environment variable.
 	 */
 	@DataBoundConstructor
 	public RepoScm(final String manifestRepositoryUrl,
@@ -210,7 +229,8 @@ public class RepoScm extends SCM {
 			final String manifestGroup, final String mirrorDir, final int jobs,
 			final String localManifest, final String destinationDir,
             final String repoUrl,
-			final boolean currentBranch, final boolean quiet) {
+			final boolean currentBranch, final boolean quiet,
+			final boolean exportRevisions) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
 		this.manifestGroup = Util.fixEmptyAndTrim(manifestGroup);
@@ -222,6 +242,7 @@ public class RepoScm extends SCM {
 		this.currentBranch = currentBranch;
 		this.quiet = quiet;
 		this.repoUrl = Util.fixEmptyAndTrim(repoUrl);
+		this.exportRevisions = exportRevisions;
 	}
 
 	@Override
@@ -243,9 +264,10 @@ public class RepoScm extends SCM {
 			final SCMRevisionState baseline) throws IOException,
 			InterruptedException {
 		SCMRevisionState myBaseline = baseline;
+		AbstractBuild<?, ?> lastBuild = project.getLastBuild();
 		if (myBaseline == null) {
 			// Probably the first build, or possibly an aborted build.
-			myBaseline = getLastState(project.getLastBuild());
+			myBaseline = getLastState(lastBuild);
 			if (myBaseline == null) {
 				return PollingResult.BUILD_NOW;
 			}
@@ -260,8 +282,18 @@ public class RepoScm extends SCM {
 		} else {
 			repoDir = workspace;
 		}
+        final EnvVars environment;
+        if (lastBuild != null) {
+        	environment = lastBuild.getEnvironment(listener);
+        } else {
+        	environment = RepoUtils.getPollEnvironment(project,
+        			workspace, launcher, listener, true);
+        }
+        final String expandedManifestBranch =
+        	environment.expand(manifestBranch);
 
-		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
+		if (!checkoutCode(launcher, repoDir, expandedManifestBranch,
+			listener.getLogger())) {
 			// Some error occurred, try a build now so it gets logged.
 			return new PollingResult(myBaseline, myBaseline,
 					Change.INCOMPARABLE);
@@ -269,7 +301,7 @@ public class RepoScm extends SCM {
 
 		final RevisionState currentState =
 				new RevisionState(getStaticManifest(launcher, repoDir,
-						listener.getLogger()), manifestBranch,
+						listener.getLogger()), expandedManifestBranch,
 						listener.getLogger());
 		final Change change;
 		if (currentState.equals(myBaseline)) {
@@ -287,6 +319,10 @@ public class RepoScm extends SCM {
 			final BuildListener listener, final File changelogFile)
 			throws IOException, InterruptedException {
 
+        final EnvVars environment = build.getEnvironment(listener);
+        final String expandedManifestBranch =
+        		environment.expand(manifestBranch);
+
 		FilePath repoDir;
 		if (destinationDir != null) {
 			repoDir = workspace.child(destinationDir);
@@ -297,15 +333,18 @@ public class RepoScm extends SCM {
 			repoDir = workspace;
 		}
 
-		if (!checkoutCode(launcher, repoDir, listener.getLogger())) {
+		if (!checkoutCode(launcher, repoDir, expandedManifestBranch,
+				listener.getLogger())) {
 			return false;
 		}
 		final String manifest =
 				getStaticManifest(launcher, repoDir, listener.getLogger());
 		final RevisionState currentState =
-				new RevisionState(manifest, manifestBranch,
+				new RevisionState(manifest, expandedManifestBranch,
 						listener.getLogger());
 		build.addAction(currentState);
+
+		injectProjectRevisions(environment, currentState);
 		final RevisionState previousState =
 				getLastState(build.getPreviousBuild());
 
@@ -313,6 +352,43 @@ public class RepoScm extends SCM {
 				launcher, repoDir);
 		build.addAction(new TagAction(build));
 		return true;
+	}
+
+	@Override
+	public void buildEnvVars(final AbstractBuild<?, ?> build,
+			final Map<String, String> env) {
+		super.buildEnvVars(build, env);
+		if (exportRevisions) {
+			final RevisionState revState = build.getAction(RevisionState.class);
+			if (revState == null) {
+				// we have not built yet
+				return;
+			}
+			injectProjectRevisions(env, revState);
+		}
+	}
+
+	/**
+	 * Injects the project revisions into the environment.
+	 * @param env	the environment to populated.
+	 * @param revState	the revision state
+	 */
+	private void injectProjectRevisions(final Map<String, String> env,
+			final RevisionState revState) {
+		final Map<String, ProjectState> projectStateMap =
+				revState.getProjects();
+		for (Entry<String, ProjectState> mapEntry
+				: projectStateMap.entrySet()) {
+			final String projectName = mapEntry.getKey();
+			final ProjectState state = mapEntry.getValue();
+			final String projNameVar = "PROJ_REV_"
+					+ EnvVarUtils.convertToEnvVariableName(projectName);
+			final String revision = state.getRevision();
+			debug.log(Level.FINE,
+					"injecting revision environment variable: ${0}=${1}",
+					new Object[] {projNameVar, revision});
+			env.put(projNameVar, revision);
+		}
 	}
 
 	private int doSync(final Launcher launcher, final FilePath workspace,
@@ -336,11 +412,14 @@ public class RepoScm extends SCM {
 		int returnCode =
 				launcher.launch().stdout(logger).pwd(workspace)
 						.cmds(commands).join();
+
+		// now try and figure out the individual
 		return returnCode;
 	}
 
 	private boolean checkoutCode(final Launcher launcher,
-			final FilePath workspace, final OutputStream logger)
+			final FilePath workspace, final String expandedManifestBranch,
+			final OutputStream logger)
 			throws IOException, InterruptedException {
 		final List<String> commands = new ArrayList<String>(4);
 
@@ -350,9 +429,9 @@ public class RepoScm extends SCM {
 		commands.add("init");
 		commands.add("-u");
 		commands.add(manifestRepositoryUrl);
-		if (manifestBranch != null) {
+		if (expandedManifestBranch != null) {
 			commands.add("-b");
-			commands.add(manifestBranch);
+			commands.add(expandedManifestBranch);
 		}
 		if (manifestFile != null) {
 			commands.add("-m");

--- a/src/main/java/hudson/plugins/repo/RepoUtils.java
+++ b/src/main/java/hudson/plugins/repo/RepoUtils.java
@@ -1,0 +1,146 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, Brad Larson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.repo;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Environment;
+import hudson.model.Hudson;
+import hudson.model.Node;
+import hudson.model.StreamBuildListener;
+import hudson.model.TaskListener;
+import hudson.slaves.NodeProperty;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Copied from git plugin GitUtils.
+ * @author Rainer Burgstaller
+ */
+public final class RepoUtils {
+
+    /**
+     * Private constructor to prevent construction.
+     */
+    private RepoUtils() {
+    }
+
+    /**
+     * An attempt to generate at least semi-useful EnvVars for polling calls,
+     * based on previous build. Cribbed from various places.
+     * <p>
+     * Copied from GitUtils from the Git plugin. I did not want to add a
+     * dependency on that plugin.
+     *
+     * @param p project
+     * @param ws	workspace
+     * @param launcher	the launcher
+     * @param listener	the listener
+     * @param reuseLastBuildEnv	true for reusing
+     * @return the environment variables
+     * @throws IOException if something bad happens
+     * @throws InterruptedException if something bad happens
+     */
+    public static EnvVars getPollEnvironment(final AbstractProject p,
+	    final FilePath ws,
+	    final Launcher launcher, final TaskListener listener,
+	    final boolean reuseLastBuildEnv)
+	    throws IOException, InterruptedException {
+	EnvVars env;
+	StreamBuildListener buildListener = new StreamBuildListener(
+		(OutputStream) listener.getLogger());
+	AbstractBuild b = (AbstractBuild) p.getLastBuild();
+
+	if (reuseLastBuildEnv && b != null) {
+	    Node lastBuiltOn = b.getBuiltOn();
+
+	    if (lastBuiltOn != null) {
+		env = lastBuiltOn.toComputer().getEnvironment()
+			.overrideAll(b.getCharacteristicEnvVars());
+		for (NodeProperty nodeProperty : lastBuiltOn
+			.getNodeProperties()) {
+		    Environment environment = nodeProperty.setUp(b, launcher,
+			    (BuildListener) buildListener);
+		    if (environment != null) {
+			environment.buildEnvVars(env);
+		    }
+		}
+	    } else {
+		env = new EnvVars(System.getenv());
+	    }
+
+	    p.getScm().buildEnvVars(b, env);
+
+//	    if (lastBuiltOn != null) {
+//
+//	    }
+
+	} else {
+	    env = new EnvVars(System.getenv());
+	}
+
+	String rootUrl = Hudson.getInstance().getRootUrl();
+	if (rootUrl != null) {
+	    env.put("HUDSON_URL", rootUrl); // Legacy.
+	    env.put("JENKINS_URL", rootUrl);
+	    if (b != null) {
+		env.put("BUILD_URL", rootUrl + b.getUrl());
+	    }
+	    env.put("JOB_URL", rootUrl + p.getUrl());
+	}
+
+	if (!env.containsKey("HUDSON_HOME")) {
+	    // Legacy
+	    env.put("HUDSON_HOME",
+		    Hudson.getInstance().getRootDir().getPath());
+	}
+
+	if (!env.containsKey("JENKINS_HOME")) {
+	    env.put("JENKINS_HOME",
+		    Hudson.getInstance().getRootDir().getPath());
+	}
+
+	if (ws != null) {
+	    env.put("WORKSPACE", ws.getRemote());
+	}
+
+	for (NodeProperty nodeProperty : Hudson.getInstance()
+		.getGlobalNodeProperties()) {
+	    Environment environment = nodeProperty.setUp(b, launcher,
+		    (BuildListener) buildListener);
+	    if (environment != null) {
+		environment.buildEnvVars(env);
+	    }
+	}
+
+	EnvVars.resolve(env);
+
+	return env;
+    }
+}

--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -118,6 +118,16 @@ public class RevisionState extends SCMRevisionState implements Serializable {
 		}
 	}
 
+	/**
+	 * Returns all listed projects along with their state.
+	 * @return the list of projects keyed by the project name,
+	 * 		the value is the project state containing the actual
+	 * 		SHA1 IDs etc.
+	 */
+	public Map<String, ProjectState> getProjects() {
+		return projects;
+	}
+
 	@Override
 	public boolean equals(final Object obj) {
 		if (obj instanceof RevisionState) {

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -50,6 +50,11 @@
 			   checked="${h.defaultToTrue(scm.quiet)}" />
 		</f:entry>
 
+        <f:entry title="Export Project Revisions as Variables" help="/plugin/repo/help-exportRevisions.html">
+            <f:checkbox name="repo.exportRevisions"
+               checked="${scm.exportRevisions}" />
+        </f:entry>
+
 		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">
 			<f:textarea name="repo.localManifest" value="${scm.localManifest}" rows="10" />
 		</f:entry>

--- a/src/main/webapp/help-exportRevisions.html
+++ b/src/main/webapp/help-exportRevisions.html
@@ -1,0 +1,24 @@
+<div>
+   <p>
+	 if <code>true</code> then the build will set environment
+     variables for each project in the repo. The project name
+     will be used as the key and the value will be set to the
+     revision number of the project. The project name will be
+     converted to a valid environment variable.
+     <h4>Example</h4>
+     Lets assume that we have a manifest with 3 repositories:
+     <ul>
+        <li><code>core</code></li>
+        <li><code>common</code></li>
+        <li><code>app</code></li>
+     </ul>
+     Then the plugin will create the following environment 
+     variables:
+     <ul>
+        <li><code>REPO_REV_CORE=8e52f38771c3163ec67ae32a6d35364e720ef3a8</code></li>
+        <li><code>REPO_REV_COMMON=f41af34f824a690463e157a4d2c531fa63ce6cc8</code></li>
+        <li><code>REPO_REV_APP=fdf57f76eb5cb9bd351552f7bf85be3987427918</code></li>
+     </ul>
+     
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/repo/EnvVarUtilsTest.java
+++ b/src/test/java/hudson/plugins/repo/EnvVarUtilsTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Brad Larson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package hudson.plugins.repo;
 
 import junit.framework.Assert;

--- a/src/test/java/hudson/plugins/repo/EnvVarUtilsTest.java
+++ b/src/test/java/hudson/plugins/repo/EnvVarUtilsTest.java
@@ -1,0 +1,16 @@
+package hudson.plugins.repo;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+public class EnvVarUtilsTest {
+
+	@Test
+	public void testConvertToEnvVariableName() {
+		Assert.assertEquals("MY_NAME", EnvVarUtils.convertToEnvVariableName("my-name"));
+		Assert.assertEquals("MY_NAME", EnvVarUtils.convertToEnvVariableName("my#name"));
+		Assert.assertEquals("MY1_NAME", EnvVarUtils.convertToEnvVariableName("my1=name"));
+	}
+
+}


### PR DESCRIPTION
... for exporting project revisions

This change addresses 2 separate issues

1. JENKINS-17913 asked for being able to expand variables for certain configuration properties
I have added expansion for the specified branch which allows users to choose a branch to checkout
and pass it in as a variable

2. I like to pass on the revision that was checked out per repo project on to sub-jobs, therefore
I have added a configuration switch where the user can enable this feature. These values
will then be added to the build environment

I know I should have split the patch in two but I thought about that too late.