### PR TITLE
Add option for --first-parent in changelog

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -43,7 +43,7 @@ Checkstyle configuration that checks coding conventions.
     <module name="UnusedImports"/>
     <module name="MethodLength"/>
     <module name="ParameterNumber">
-      <property name="max" value="14"/>
+      <property name="max" value="15"/>
     </module>
     <module name="LineLength">
       <property name="tabWidth" value="4"/>

--- a/src/main/java/hudson/plugins/repo/ChangeLog.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLog.java
@@ -95,7 +95,7 @@ public class ChangeLog extends ChangeLogParser {
 	 * @param workspace
 	 *            The FilePath of the workspace to use when computing
 	 *            differences. This path might be on a slave machine.
-	 * @param firstParent
+	 * @param showAllChanges
 	 *            Add --first-parent to "git log"
 	 * @throws IOException
 	 *             is thrown if we have problems writing to the changelogFile
@@ -106,7 +106,7 @@ public class ChangeLog extends ChangeLogParser {
 	public static List<ChangeLogEntry> generateChangeLog(
 			final RevisionState currentState,
 			final RevisionState previousState, final Launcher launcher,
-			final FilePath workspace, final boolean firstParent)
+			final FilePath workspace, final boolean showAllChanges)
 			throws IOException,
 			InterruptedException {
 		final List<ProjectState> changes =
@@ -144,7 +144,7 @@ public class ChangeLog extends ChangeLogParser {
 			commands.add("git");
 			commands.add("log");
 			commands.add("--raw");
-			if (firstParent) {
+			if (!showAllChanges) {
 				commands.add("--first-parent");
 			}
 
@@ -230,7 +230,7 @@ public class ChangeLog extends ChangeLogParser {
 	 * @param workspace
 	 *            The FilePath of the workspace to use when computing
 	 *            differences. This path might be on a slave machine.
-	 * @param firstParent
+	 * @param showAllChanges
 	 *            Add --first-parent to "git log"
 	 * @throws IOException
 	 *             is thrown if we have problems writing to the changelogFile
@@ -241,11 +241,11 @@ public class ChangeLog extends ChangeLogParser {
 	public static void saveChangeLog(final RevisionState currentState,
 			final RevisionState previousState, final File changelogFile,
 			final Launcher launcher, final FilePath workspace,
-			final boolean firstParent)
+			final boolean showAllChanges)
 			throws IOException, InterruptedException {
 		List<ChangeLogEntry> logs =
 				generateChangeLog(currentState, previousState, launcher,
-						workspace, firstParent);
+						workspace, showAllChanges);
 
 		if (logs == null) {
 			debug.info("No logs found");

--- a/src/main/java/hudson/plugins/repo/ChangeLog.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLog.java
@@ -95,6 +95,8 @@ public class ChangeLog extends ChangeLogParser {
 	 * @param workspace
 	 *            The FilePath of the workspace to use when computing
 	 *            differences. This path might be on a slave machine.
+	 * @param firstParent
+	 *            Add --first-parent to "git log"
 	 * @throws IOException
 	 *             is thrown if we have problems writing to the changelogFile
 	 * @throws InterruptedException
@@ -104,7 +106,8 @@ public class ChangeLog extends ChangeLogParser {
 	public static List<ChangeLogEntry> generateChangeLog(
 			final RevisionState currentState,
 			final RevisionState previousState, final Launcher launcher,
-			final FilePath workspace) throws IOException,
+			final FilePath workspace, final boolean firstParent)
+			throws IOException,
 			InterruptedException {
 		final List<ProjectState> changes =
 				currentState.whatChanged(previousState);
@@ -141,7 +144,9 @@ public class ChangeLog extends ChangeLogParser {
 			commands.add("git");
 			commands.add("log");
 			commands.add("--raw");
-			commands.add("--first-parent");
+			if (firstParent) {
+				commands.add("--first-parent");
+			}
 
             final String format = "[[<as7d9m1R_MARK_A>]]"
                                 + "%H[[<as7d9m1R_MARK_B>]"
@@ -225,6 +230,8 @@ public class ChangeLog extends ChangeLogParser {
 	 * @param workspace
 	 *            The FilePath of the workspace to use when computing
 	 *            differences. This path might be on a slave machine.
+	 * @param firstParent
+	 *            Add --first-parent to "git log"
 	 * @throws IOException
 	 *             is thrown if we have problems writing to the changelogFile
 	 * @throws InterruptedException
@@ -233,11 +240,12 @@ public class ChangeLog extends ChangeLogParser {
 	 */
 	public static void saveChangeLog(final RevisionState currentState,
 			final RevisionState previousState, final File changelogFile,
-			final Launcher launcher, final FilePath workspace)
+			final Launcher launcher, final FilePath workspace,
+			final boolean firstParent)
 			throws IOException, InterruptedException {
 		List<ChangeLogEntry> logs =
 				generateChangeLog(currentState, previousState, launcher,
-						workspace);
+						workspace, firstParent);
 
 		if (logs == null) {
 			debug.info("No logs found");

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -91,6 +91,7 @@ public class RepoScm extends SCM implements Serializable {
 	private final boolean resetFirst;
 	private final boolean quiet;
 	private final boolean trace;
+	private final boolean firstParent;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -228,6 +229,11 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public boolean resetFirst() { return resetFirst; }
 	/**
+	 * Returns the value of firstParent.
+	 */
+	@Exported
+	public boolean firstParent() { return firstParent; }
+	/**
 	 * Returns the value of quiet.
 	 */
 	@Exported
@@ -284,6 +290,9 @@ public class RepoScm extends SCM implements Serializable {
 	 * @param trace
 	 *            If this value is true, add the "--trace" option when
 	 *            executing "repo init" and "repo sync".
+	 * @param firstParent
+	 *            If this value is true, add the "--first-parent" option to
+	 *            "git log" when determining changesets.
 	 */
 	@DataBoundConstructor
 	public RepoScm(final String manifestRepositoryUrl,
@@ -295,7 +304,8 @@ public class RepoScm extends SCM implements Serializable {
 			final boolean currentBranch,
 			final boolean resetFirst,
 			final boolean quiet,
-			final boolean trace) {
+			final boolean trace,
+			final boolean firstParent) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
 		this.manifestGroup = Util.fixEmptyAndTrim(manifestGroup);
@@ -309,6 +319,7 @@ public class RepoScm extends SCM implements Serializable {
 		this.resetFirst = resetFirst;
 		this.quiet = quiet;
 		this.trace = trace;
+		this.firstParent = firstParent;
 		this.repoUrl = Util.fixEmptyAndTrim(repoUrl);
 	}
 
@@ -410,7 +421,7 @@ public class RepoScm extends SCM implements Serializable {
 				getLastState(previousBuild, expandedBranch);
 
 		ChangeLog.saveChangeLog(currentState, previousState, changelogFile,
-				launcher, repoDir);
+				launcher, repoDir, firstParent);
 		build.addAction(new TagAction(build));
 		return true;
 	}

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -91,7 +91,7 @@ public class RepoScm extends SCM implements Serializable {
 	private final boolean resetFirst;
 	private final boolean quiet;
 	private final boolean trace;
-	private final boolean firstParent;
+	private final boolean showAllChanges;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -229,10 +229,10 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public boolean resetFirst() { return resetFirst; }
 	/**
-	 * Returns the value of firstParent.
+	 * Returns the value of showAllChanges.
 	 */
 	@Exported
-	public boolean firstParent() { return firstParent; }
+	public boolean showAllChanges() { return showAllChanges; }
 	/**
 	 * Returns the value of quiet.
 	 */
@@ -290,7 +290,7 @@ public class RepoScm extends SCM implements Serializable {
 	 * @param trace
 	 *            If this value is true, add the "--trace" option when
 	 *            executing "repo init" and "repo sync".
-	 * @param firstParent
+	 * @param showAllChanges
 	 *            If this value is true, add the "--first-parent" option to
 	 *            "git log" when determining changesets.
 	 */
@@ -305,7 +305,7 @@ public class RepoScm extends SCM implements Serializable {
 			final boolean resetFirst,
 			final boolean quiet,
 			final boolean trace,
-			final boolean firstParent) {
+			final boolean showAllChanges) {
 		this.manifestRepositoryUrl = manifestRepositoryUrl;
 		this.manifestBranch = Util.fixEmptyAndTrim(manifestBranch);
 		this.manifestGroup = Util.fixEmptyAndTrim(manifestGroup);
@@ -319,7 +319,7 @@ public class RepoScm extends SCM implements Serializable {
 		this.resetFirst = resetFirst;
 		this.quiet = quiet;
 		this.trace = trace;
-		this.firstParent = firstParent;
+		this.showAllChanges = showAllChanges;
 		this.repoUrl = Util.fixEmptyAndTrim(repoUrl);
 	}
 
@@ -421,7 +421,7 @@ public class RepoScm extends SCM implements Serializable {
 				getLastState(previousBuild, expandedBranch);
 
 		ChangeLog.saveChangeLog(currentState, previousState, changelogFile,
-				launcher, repoDir, firstParent);
+				launcher, repoDir, showAllChanges);
 		build.addAction(new TagAction(build));
 		return true;
 	}

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -60,8 +60,8 @@
 			<f:checkbox name="repo.trace" checked="${scm.trace}" />
 		</f:entry>
 
-		<f:entry title="First parent" help="/plugin/repo/help-firstParent.html">
-			<f:checkbox name="repo.firstParent" checked="${h.defaultToTrue(scm.firstParent)}" />
+		<f:entry title="Show all changes" help="/plugin/repo/help-showAllChanges.html">
+			<f:checkbox name="repo.showAllChanges" checked="${h.defaultToFalse(scm.showAllChanges)}" />
 		</f:entry>
 
 		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -60,6 +60,10 @@
 			<f:checkbox name="repo.trace" checked="${scm.trace}" />
 		</f:entry>
 
+		<f:entry title="First parent" help="/plugin/repo/help-firstParent.html">
+			<f:checkbox name="repo.firstParent" checked="${h.defaultToTrue(scm.firstParent)}" />
+		</f:entry>
+
 		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">
 			<f:textarea name="repo.localManifest" value="${scm.localManifest}" rows="10" />
 		</f:entry>

--- a/src/main/webapp/help-firstParent.html
+++ b/src/main/webapp/help-firstParent.html
@@ -1,6 +1,0 @@
-<div>
-  <p>
-    When this is checked <code>--first-parent</code> is passed to <code>git 
-      log</code> when determining changesets.
-  </p>
-</div>

--- a/src/main/webapp/help-firstParent.html
+++ b/src/main/webapp/help-firstParent.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    When this is checked <code>--first-parent</code> is passed to <code>git 
+      log</code> when determining changesets.
+  </p>
+</div>

--- a/src/main/webapp/help-showAllChanges.html
+++ b/src/main/webapp/help-showAllChanges.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    When this is checked <code>--first-parent</code> is no longer passed
+    to <code>git log</code> when determining changesets.
+  </p>
+</div>


### PR DESCRIPTION
This adds an option to select whether or not --first-parent is
passed to "git log" when determining the changelog.  The default
value is to include it.