### PR TITLE
Fix for checked options not persisting

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -227,12 +227,21 @@ public class RepoScm extends SCM implements Serializable {
 	 * Returns the value of resetFirst.
 	 */
 	@Exported
-	public boolean resetFirst() { return resetFirst; }
+	public boolean isResetFirst() { return resetFirst; }
 	/**
 	 * Returns the value of showAllChanges.
 	 */
 	@Exported
-	public boolean showAllChanges() { return showAllChanges; }
+	public boolean isShowAllChanges() {
+		return showAllChanges;
+	}
+	/**
+	 * Returns the value of trace.
+	 */
+	@Exported
+	public boolean isTrace() {
+		return trace;
+	}
 	/**
 	 * Returns the value of quiet.
 	 */
@@ -421,7 +430,7 @@ public class RepoScm extends SCM implements Serializable {
 				getLastState(previousBuild, expandedBranch);
 
 		ChangeLog.saveChangeLog(currentState, previousState, changelogFile,
-				launcher, repoDir, showAllChanges);
+				launcher, repoDir, isShowAllChanges());
 		build.addAction(new TagAction(build));
 		return true;
 	}
@@ -432,7 +441,7 @@ public class RepoScm extends SCM implements Serializable {
 		final List<String> commands = new ArrayList<String>(4);
 		debug.log(Level.FINE, "Syncing out code in: " + workspace.getName());
 		commands.clear();
-		if (resetFirst) {
+		if (isResetFirst()) {
 			commands.add(getDescriptor().getExecutable());
 			commands.add("forall");
 			commands.add("-c");
@@ -446,7 +455,7 @@ public class RepoScm extends SCM implements Serializable {
 			commands.clear();
 		}
 		commands.add(getDescriptor().getExecutable());
-		if (trace) {
+		if (isTrace()) {
 		    commands.add("--trace");
 		}
 		commands.add("sync");
@@ -476,7 +485,7 @@ public class RepoScm extends SCM implements Serializable {
 		debug.log(Level.INFO, "Checking out code in: " + workspace.getName());
 
 		commands.add(getDescriptor().getExecutable());
-		if (trace) {
+		if (isTrace()) {
 		    commands.add("--trace");
 		}
 		commands.add("init");

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -61,7 +61,7 @@
 		</f:entry>
 
 		<f:entry title="Show all changes" help="/plugin/repo/help-showAllChanges.html">
-			<f:checkbox name="repo.showAllChanges" checked="${h.defaultToFalse(scm.showAllChanges)}" />
+			<f:checkbox name="repo.showAllChanges" checked="${scm.showAllChanges}" />
 		</f:entry>
 
 		<f:entry title="Local Manifest" help="/plugin/repo/help-localManifest.html">


### PR DESCRIPTION
This fixes a problem where you will check one of the affected options, save,
and the option is not checked the next time you go to configure.  The solution
is to make sure that all accesses to the variable use an accessor.