### PR TITLE
Add support for repo sync --no-tags

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -43,7 +43,7 @@ Checkstyle configuration that checks coding conventions.
     <module name="UnusedImports"/>
     <module name="MethodLength"/>
     <module name="ParameterNumber">
-      <property name="max" value="15"/>
+      <property name="max" value="16"/>
     </module>
     <module name="LineLength">
       <property name="tabWidth" value="4"/>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version><!-- which version of Hudson is this plugin built against? -->
+    <version>1.580.1</version><!-- which version of Hudson is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -56,6 +56,7 @@ import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
@@ -92,6 +93,7 @@ public class RepoScm extends SCM implements Serializable {
 	private final boolean quiet;
 	private final boolean trace;
 	private final boolean showAllChanges;
+	private boolean noTags;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -245,6 +247,11 @@ public class RepoScm extends SCM implements Serializable {
 	 */
 	@Exported
 	public boolean isTrace() { return trace; }
+	/**
+	 * Returns the value of noTags.
+	 */
+	@Exported
+	public boolean isNoTags() { return noTags; }
 
 	/**
 	 * The constructor takes in user parameters and sets them. Each job using
@@ -326,6 +333,18 @@ public class RepoScm extends SCM implements Serializable {
 		this.trace = trace;
 		this.showAllChanges = showAllChanges;
 		this.repoUrl = Util.fixEmptyAndTrim(repoUrl);
+	}
+
+	/**
+	 * Set noTags.
+	 *
+	 * @param noTags
+	 *            If this value is true, add the "--no-tags" option when
+	 *            executing "repo sync".
+	 */
+	@DataBoundSetter
+	public final void setNoTags(final boolean noTags) {
+		this.noTags = noTags;
 	}
 
 	@Override
@@ -465,6 +484,10 @@ public class RepoScm extends SCM implements Serializable {
 		if (jobs > 0) {
 			commands.add("--jobs=" + jobs);
 		}
+		if (isNoTags()) {
+			commands.add("--no-tags");
+		}
+
 		int returnCode =
 				launcher.launch().stdout(logger).pwd(workspace)
 						.cmds(commands).envs(env).join();

--- a/src/main/java/hudson/plugins/repo/TagAction.java
+++ b/src/main/java/hudson/plugins/repo/TagAction.java
@@ -23,7 +23,7 @@
  */
 package hudson.plugins.repo;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.scm.AbstractScmTagAction;
 
 import org.kohsuke.stapler.export.ExportedBean;
@@ -42,7 +42,7 @@ public class TagAction extends AbstractScmTagAction {
 	 * @param build
 	 *            Build which we are interested in tagging
 	 */
-	TagAction(final AbstractBuild<?, ?> build) {
+	TagAction(final Run<?, ?> build) {
 		super(build);
 	}
 

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -56,6 +56,10 @@
 			<f:checkbox name="repo.quiet" checked="${h.defaultToTrue(scm.quiet)}" />
 		</f:entry>
 
+		<f:entry title="No tags" help="/plugin/repo/help-noTags.html">
+			<f:checkbox name="repo.noTags" checked="${scm.noTags}" />
+		</f:entry>
+
 		<f:entry title="Trace" help="/plugin/repo/help-trace.html">
 			<f:checkbox name="repo.trace" checked="${scm.trace}" />
 		</f:entry>

--- a/src/main/webapp/help-noTags.html
+++ b/src/main/webapp/help-noTags.html
@@ -1,0 +1,6 @@
+<div>
+   <p>
+   Don't fetch tags.
+   This is passed to repo as <code>repo sync <i>--no-tags</i></code>.
+  </p>
+</div>


### PR DESCRIPTION
This series updates the parent to 1.580.1 to enable @DataBoundSetter.
The version number is according to https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md#plugin-developer-guide.

Then, repo sync --no-tags support is added.
Fixes JENKINS-30618.