### PR TITLE
adding an option to ignore specific projects on scm poll.

### DIFF
--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -23,6 +23,10 @@
 		<f:entry title="Group" help="/plugin/repo/help-manifestGroup.html">
 			<f:textbox name="repo.manifestGroup" value="${scm.manifestGroup}" />
 		</f:entry>
+		
+		<f:entry title="IgnoreChanges" help="/plugin/repo/help-ignoreChanges.html">
+			<f:textarea name="repo.ignoreProjects" value="${scm.ignoreProjects}" rows="3" />
+		</f:entry>
 
 		<f:entry title="Destination Directory" help="/plugin/repo/help-destinationDir.html">
 			<f:textbox name="repo.destinationDir" value="${scm.destinationDir}" />

--- a/src/main/webapp/help-ignoreChanges.html
+++ b/src/main/webapp/help-ignoreChanges.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Specify projects changes in which would not be considered a change that requires project rebuild when polling scm.
+    Project should be specified as the name in the <code>name</code> section of the <code>project</code> declaration in manifest separated by spaces. 
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/repo/TestRepoScm.java
+++ b/src/test/java/hudson/plugins/repo/TestRepoScm.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Brad Larson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.repo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+
+import junit.framework.TestCase;
+
+/**
+ * Test cases for the {@link RevisionState} class.
+ */
+public class TestRepoScm extends TestCase {
+
+
+	public void testSetIgnoredProjects() {
+		RepoScm scm = new RepoScm("http://manifesturl");
+		scm.setIgnoreProjects("");
+		assertEquals("", scm.getIgnoreProjects());
+		
+	}
+
+	public void testSetIgnoredProjectsKeepsOrder() {
+		RepoScm scm = new RepoScm("http://manifesturl");
+		scm.setIgnoreProjects("projecta projectb");
+		assertEquals("projecta\nprojectb", scm.getIgnoreProjects());
+		scm.setIgnoreProjects("projectb projecta");
+		assertEquals("projectb\nprojecta", scm.getIgnoreProjects());
+	}
+}


### PR DESCRIPTION
This adds an ability to "ignore" changes on specific project while "polling" for changes from the scm.
This is useful for example when the build process itself commits a change to specific repository, to avoid re-trigger the build. 
