### PR TITLE
Fix issue with Email Ext plugin - full name was returned instead of email

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
@@ -279,7 +279,7 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 		if (authorName == null) {
 			return User.getUnknown();
 		}
-		return User.get(authorName);
+		return User.get(authorEmail);
 	}
 
 	@Override


### PR DESCRIPTION

The Email Ext plugin tries to send email to the commits and the repo plugin
returns the committers full name instead of the email address.  This
causes the Email Ext to send emails for "John Doe <jdoe@jenkins.com>" to
"John@jenkins.com" and "Doe@jenkins.com" instead of jdoe@jenkins.com.
Fixes JENKINS-14539.