### PR TITLE
Expand local manifest

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -814,10 +814,11 @@ public class RepoScm extends SCM implements Serializable {
 			FilePath lm = rdir.child("local_manifest.xml");
 			lm.delete();
 			if (localManifest != null) {
-				if (localManifest.startsWith("<?xml")) {
-					lm.write(localManifest, null);
+				String expandedLocalManifest = env.expand(localManifest);
+				if (expandedLocalManifest.startsWith("<?xml")) {
+					lm.write(expandedLocalManifest, null);
 				} else {
-					URL url = new URL(localManifest);
+					URL url = new URL(expandedLocalManifest);
 					lm.copyFrom(url);
 				}
 			}

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -121,8 +121,9 @@ public class RepoScm extends SCM implements Serializable {
 	}
 
 	/**
-	 * Same as {@link #getManifestBranch()} but with <em>default</em>
-	 * values of parameters expanded.
+	 * Merge the provided environment with the <em>default</em> values of
+	 * the project parameters. The values from the provided environment
+	 * take precedence.
 	 * @param environment   an existing environment, which contains already
 	 *                      properties from the current build
 	 * @param project       the project that is being built


### PR DESCRIPTION
Variable expansion works for all other fields, but not for the local manifest. This makes it impossible to define the local manifest or its URL using environment variables or a pre SCM step.

My only concern about this change is that there might be a good reason why it was not implemented for the local manifest so far. If so I could improve the pull request and add a checkbox like "Do not expand variables in local manifest".

Also see https://issues.jenkins-ci.org/browse/JENKINS-37416 .