### PR TITLE
Fix typos in local manifest help

### DIFF
--- a/src/main/webapp/help-localManifest.html
+++ b/src/main/webapp/help-localManifest.html
@@ -1,7 +1,7 @@
 <div>
   <p>
      The contents of <code>.repo/local_manifest.xml</code>. This is written prior to
-callinging sync. The default is to not use a <code>local_manifest.txt</code> file.
+calling sync. The default is to not use a <code>local_manifest.xml</code> file.
   </p>
   <p>The contents may be given here literally, as XML; see the example below.
 Such literal content <b>must</b> start with the


### PR DESCRIPTION
Just fixed two typos in the help text.