### PR TITLE
Fix some repo commands

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -656,8 +656,8 @@ public class RepoScm extends SCM implements Serializable {
 		}
 
 		final RevisionState currentState = new RevisionState(
-				getStaticManifest(launcher, repoDir, listener.getLogger()),
-				getManifestRevision(launcher, repoDir, listener.getLogger()),
+				getStaticManifest(launcher, repoDir, listener.getLogger(), env),
+				getManifestRevision(launcher, repoDir, listener.getLogger(), env),
 				expandedManifestBranch, listener.getLogger());
 
 		final Change change;
@@ -699,9 +699,9 @@ public class RepoScm extends SCM implements Serializable {
 			throw new IOException("Could not checkout");
 		}
 		final String manifest =
-				getStaticManifest(launcher, repoDir, listener.getLogger());
+				getStaticManifest(launcher, repoDir, listener.getLogger(), env);
 		final String manifestRevision =
-				getManifestRevision(launcher, repoDir, listener.getLogger());
+				getManifestRevision(launcher, repoDir, listener.getLogger(), env);
 		final String expandedBranch = env.expand(manifestBranch);
 		final RevisionState currentState =
 				new RevisionState(manifest, manifestRevision, expandedBranch,
@@ -736,7 +736,7 @@ public class RepoScm extends SCM implements Serializable {
 			commands.add("-c");
 			commands.add("git reset --hard");
 			int syncCode = launcher.launch().stdout(logger)
-				.stderr(logger).pwd(workspace).cmds(commands).join();
+				.stderr(logger).pwd(workspace).cmds(commands).envs(env).join();
 
 			if (syncCode != 0) {
 				debug.log(Level.WARNING, "Failed to reset first.");
@@ -847,7 +847,8 @@ public class RepoScm extends SCM implements Serializable {
 	}
 
 	private String getStaticManifest(final Launcher launcher,
-			final FilePath workspace, final OutputStream logger)
+			final FilePath workspace, final OutputStream logger,
+			final EnvVars env)
 			throws IOException, InterruptedException {
 		final ByteArrayOutputStream output = new ByteArrayOutputStream();
 		final List<String> commands = new ArrayList<String>(6);
@@ -858,14 +859,15 @@ public class RepoScm extends SCM implements Serializable {
 		commands.add("-r");
 		// TODO: should we pay attention to the output from this?
 		launcher.launch().stderr(logger).stdout(output).pwd(workspace)
-				.cmds(commands).join();
+				.cmds(commands).envs(env).join();
 		final String manifestText = output.toString();
 		debug.log(Level.FINEST, manifestText);
 		return manifestText;
 	}
 
 	private String getManifestRevision(final Launcher launcher,
-			final FilePath workspace, final OutputStream logger)
+			final FilePath workspace, final OutputStream logger,
+			final EnvVars env)
 			throws IOException, InterruptedException {
 		final ByteArrayOutputStream output = new ByteArrayOutputStream();
 		final List<String> commands = new ArrayList<String>(6);
@@ -874,7 +876,7 @@ public class RepoScm extends SCM implements Serializable {
 		commands.add("HEAD");
 		launcher.launch().stderr(logger).stdout(output).pwd(
 				new FilePath(workspace, ".repo/manifests"))
-				.cmds(commands).join();
+				.cmds(commands).envs(env).join();
 		final String manifestText = output.toString().trim();
 		debug.log(Level.FINEST, manifestText);
 		return manifestText;


### PR DESCRIPTION
Commands 'repo forall -c "git reset --hard"' and "repo manifest"
didn't work because environnement was not injected  when command
was executed

Signed-off-by: Sébastien Mennetrier <smennetrier@voxtok.com>