### PR TITLE
Fix --force-sync help description

### DIFF
--- a/src/main/webapp/help-forceSync.html
+++ b/src/main/webapp/help-forceSync.html
@@ -1,6 +1,7 @@
 <div>
    <p>
-	 Continue sync even if a project fails to sync
+        Overwrite an existing git directory if it needs to point to a different
+        object directory. WARNING: this may cause loss of data.
    This is passed to repo as <code>repo sync <i>--force-sync</i></code>.
   </p>
 </div>


### PR DESCRIPTION
From the repo sync help page as of the latest release v1.12.37, the
--force-sync option is used to overwrite an existing project git
directory if it needs to point to a different object directory.

Currently, the help uses the description for -f, --force-broken instead
of --force-sync.