### PR TITLE
Added support to clean the Working copy before running the checkout. …

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -101,6 +101,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private boolean trace;
 	@CheckForNull private boolean showAllChanges;
 	@CheckForNull private boolean noTags;
+	@CheckForNull private boolean alwaysClean;
 	@CheckForNull private Set<String> ignoreProjects;
 
 	/**
@@ -242,6 +243,14 @@ public class RepoScm extends SCM implements Serializable {
 	public boolean isCurrentBranch() {
 		return currentBranch;
 	}
+
+	/**
+	 * Returns the repo alwaysClean.
+	 */
+	@Exported
+	public boolean isAlwaysClean() {
+		return alwaysClean;
+	}
 	/**
 	 * Returns the value of resetFirst.the initial manifest file name.
 	 */
@@ -372,6 +381,7 @@ public class RepoScm extends SCM implements Serializable {
 		trace = false;
 		showAllChanges = false;
 		noTags = false;
+		alwaysClean = false;
 		ignoreProjects = Collections.<String>emptySet();
 	}
 
@@ -503,12 +513,24 @@ public class RepoScm extends SCM implements Serializable {
 	 * Set quiet.
 	 *
 	 * @param quiet
-	 * *      If this value is true, add the "-q" option when executing
-	 *        "repo sync".
+	 *       If this value is true, add the "-q" option when executing
+	 *       "repo sync".
      */
 	@DataBoundSetter
 	public void setQuiet(final boolean quiet) {
 		this.quiet = quiet;
+	}
+
+	/**
+	 * Set always clean.
+	 *
+	 * @param alwaysClean
+	 *            If this value is true, The WC is wiped before checking out new
+	 *            source
+	 */
+	@DataBoundSetter
+	public void setAlwaysClean(@CheckForNull final boolean alwaysClean) {
+		this.alwaysClean = alwaysClean;
 	}
 
 	/**
@@ -681,6 +703,12 @@ public class RepoScm extends SCM implements Serializable {
 			@Nonnull final FilePath workspace, @Nonnull final TaskListener listener,
 			@CheckForNull final File changelogFile, @CheckForNull final SCMRevisionState baseline)
 			throws IOException, InterruptedException {
+		if (alwaysClean) {
+			listener.getLogger().println("Cleaning " + workspace.getRemote());
+			if (workspace.exists()) {
+				workspace.deleteContents();
+			}
+		}
 
 		Job<?, ?> job = build.getParent();
 		EnvVars env = build.getEnvironment(listener);

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -68,6 +68,10 @@
 			<f:checkbox name="repo.noTags" checked="${scm.noTags}" />
 		</f:entry>
 
+		<f:entry title="Always clean" help="/plugin/repo/help-alwaysClean.html">
+			<f:checkbox name="repo.alwaysClean" checked="${scm.alwaysClean}" />
+		</f:entry>
+
 		<f:entry title="Trace" help="/plugin/repo/help-trace.html">
 			<f:checkbox name="repo.trace" checked="${scm.trace}" />
 		</f:entry>

--- a/src/main/webapp/help-alwaysClean.html
+++ b/src/main/webapp/help-alwaysClean.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Always clean the working copy before checking out the source code.
+  </p>
+</div>


### PR DESCRIPTION
This is mostly needed when running with the pipeline plugin as there is no easy way to add a build wrapper to cleanup. The clean uses the Jenkins deleteContent to delete the content in the folder and can be slow on larger working copys on some filesystems

Change-Id: I773c85b8466e70fdc739836d067d9b8843b41960