### PR TITLE
Fix raw diff parsing

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
@@ -45,29 +45,20 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 	 */
 	static class ModifiedFile implements AffectedFile {
 
-		/**
-		 * An EditType for a Renamed file. Most version control systems don't
-		 * support file renames, so this EditType isn't in the default set
-		 * provided by Hudson.
-		 */
-		static final EditType RENAME = new EditType("rename",
-				"The file was renamed");
-
 		private final String path;
-		private final char action;
+		private final EditType editType;
 
 		/**
-		 * Create a new ModifiedFile object with the given path and action.
+		 * Create a new ModifiedFile object with the given path and edit type.
 		 *
 		 * @param path
 		 *            the path of the file
-		 * @param action
-		 *            the action performed on the file, as reported by Git (A
-		 *            for add, D for delete, M for modified, etc)
+		 * @param editType
+		 *            edit type
 		 */
-		ModifiedFile(final String path, final char action) {
+		ModifiedFile(final String path, final EditType editType) {
 			this.path = path;
-			this.action = action;
+			this.editType = editType;
 		}
 
 		/**
@@ -78,28 +69,10 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 		}
 
 		/**
-		 * Returns the action performed on the file.
-		 */
-		public char getAction() {
-			return action;
-		}
-
-		/**
-		 * Returns the EditType performed on the file (based on the action).
+		 * Returns the EditType performed on the file.
 		 */
 		public EditType getEditType() {
-			if (action == 'A') {
-				return EditType.ADD;
-			} else if (action == 'D') {
-				return EditType.DELETE;
-			} else if (action == 'M') {
-				return EditType.EDIT;
-			} else if (action == 'R') {
-				return RENAME;
-			} else {
-				return new EditType("unknown: " + action,
-						"An unknown file action");
-			}
+			return editType;
 		}
 	}
 


### PR DESCRIPTION
The old code assumed the action/path were always at fixed positions in the line. This is not the case for at least 2 reasons:
- The length of abbreviated SHAs varies.
- The action can be followed by a score (for renames/copies).

The new code splits by space/tab as per the format described in "git diff --help". This could still break if you have filenames containing tabs but it's certainly better.

I've also gotten rid of the made-up rename EditType and just used an add+delete instead. Without support for renaming at a higher level this seems better.