### PR TITLE
Added support for --no-clone-bundle

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -104,6 +104,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private boolean showAllChanges;
 	@CheckForNull private boolean noTags;
 	@CheckForNull private Set<String> ignoreProjects;
+	@CheckForNull private boolean noCloneBundle;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -297,6 +298,13 @@ public class RepoScm extends SCM implements Serializable {
 	public boolean isNoTags() {
 		return noTags;
 	}
+	/**
+	 * Returns the value of noCloneBundle.
+	 */
+	@Exported
+	public boolean isNoCloneBundle() {
+		return noCloneBundle;
+	}
 
 	/**
 	 * The constructor takes in user parameters and sets them. Each job using
@@ -396,6 +404,7 @@ public class RepoScm extends SCM implements Serializable {
 		showAllChanges = false;
 		noTags = false;
 		ignoreProjects = Collections.<String>emptySet();
+		noCloneBundle = false;
 	}
 
 	/**
@@ -569,6 +578,18 @@ public class RepoScm extends SCM implements Serializable {
 	@DataBoundSetter
 	public void setShowAllChanges(final boolean showAllChanges) {
 		this.showAllChanges = showAllChanges;
+	}
+
+	/**
+	 * Set noCloneBundle.
+	 *
+	 * @param noCloneBundle
+	 *        If this value is true, add the "--no-clone-bundle" option when
+	 *        running the "repo init" and "repo sync" commands.
+     */
+	@DataBoundSetter
+	public void setNoCloneBundle(final boolean noCloneBundle) {
+		this.noCloneBundle = noCloneBundle;
 	}
 
 	/**
@@ -814,6 +835,9 @@ public class RepoScm extends SCM implements Serializable {
 		if (isNoTags()) {
 			commands.add("--no-tags");
 		}
+		if (isNoCloneBundle()) {
+			commands.add("--no-clone-bundle");
+		}
 
 		return launcher.launch().stdout(logger).pwd(workspace)
                 .cmds(commands).envs(env).join();
@@ -856,6 +880,9 @@ public class RepoScm extends SCM implements Serializable {
 		}
 		if (depth != 0) {
 			commands.add("--depth=" + depth);
+		}
+		if (isNoCloneBundle()) {
+			commands.add("--no-clone-bundle");
 		}
 		int returnCode =
 				launcher.launch().stdout(logger).pwd(workspace)

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -84,5 +84,9 @@
 			<f:textarea rows="10" />
 		</f:entry>
 
+		<f:entry title="No Clone Bundle" help="/plugin/repo/help-noCloneBundle.html" field="noCloneBundle">
+			<f:checkbox/>
+		</f:entry>
+
 	</f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-noCloneBundle.html
+++ b/src/main/webapp/help-noCloneBundle.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    When this is checked <code>--no-clone-bundle</code> is used when running
+    the <code>repo init</code> and <code>repo sync</code> commands.
+  </p>
+</div>


### PR DESCRIPTION
Added "No Clone Bundle" setting. If selected the "repo init" and "repo sync" commands will
be run with the --no-clone-bundle option.

I have tried it with both standard jobs and pipelines.