### PR TITLE
[JENKINS-37557] Better support for pipelines

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLog.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLog.java
@@ -124,17 +124,16 @@ class ChangeLog extends ChangeLogParser {
 		final List<String> commands = new ArrayList<String>(5);
 		final List<ChangeLogEntry> logs = new ArrayList<ChangeLogEntry>();
 
-
 		for (final ProjectState change : changes) {
 			debug.log(Level.FINEST, "change: " + change);
+			String newRevision = currentState.getRevision(change.getPath());
 			if (change.getRevision() == null) {
 				// This project was just added to the manifest.
 				logs.add(new ChangeLogEntry(change.getPath(), change
-						.getServerPath(), null, null, null, null, null, null,
+						.getServerPath(), newRevision, null, null, null, null, null,
 						null, "This project was added to the manifest.", null));
 				continue;
 			}
-			String newRevision = currentState.getRevision(change.getPath());
 			if (newRevision == null) {
 				// This project was just removed from the manifest.
 				logs.add(new ChangeLogEntry(change.getPath(), change

--- a/src/main/java/hudson/plugins/repo/ChangeLog.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLog.java
@@ -41,6 +41,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -118,7 +119,7 @@ class ChangeLog extends ChangeLogParser {
 		debug.log(Level.FINEST, "generateChangeLog: changes " + changes);
 		if (changes == null || changes.size() == 0) {
 			// No changes or the first job
-			return null;
+			return Collections.emptyList();
 		}
 		final List<String> commands = new ArrayList<String>(5);
 		final List<ChangeLogEntry> logs = new ArrayList<ChangeLogEntry>();

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -104,6 +105,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private boolean showAllChanges;
 	@CheckForNull private boolean noTags;
 	@CheckForNull private Set<String> ignoreProjects;
+	@CheckForNull private EnvVars extraEnvVars;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -152,6 +154,11 @@ public class RepoScm extends SCM implements Serializable {
 		// now merge the settings from the last build environment
 		if (environment != null) {
 			finalEnv.overrideAll(environment);
+		}
+
+		// merge extra env vars, if specified
+		if (extraEnvVars != null) {
+			finalEnv.overrideAll(extraEnvVars);
 		}
 
 		EnvVars.resolve(finalEnv);
@@ -296,6 +303,14 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public boolean isNoTags() {
 		return noTags;
+	}
+
+	/**
+	 * Returns the value of extraEnvVars.
+	 */
+	@Exported
+	public Map<String, String> getExtraEnvVars() {
+		return extraEnvVars;
 	}
 
 	/**
@@ -621,6 +636,17 @@ public class RepoScm extends SCM implements Serializable {
 		}
 		this.ignoreProjects = new LinkedHashSet<String>(
 				Arrays.asList(ignoreProjects.split("\\s+")));
+	}
+
+	/**
+	 * Set additional environment variables to use. These variables will override
+	 * any parameter from the project or variable set in environment already.
+	 * @param extraEnvVars
+	 * 			  Additional environment variables to set.
+	 */
+	@DataBoundSetter
+	public void setExtraEnvVars(@CheckForNull final Map<String, String> extraEnvVars) {
+		this.extraEnvVars = extraEnvVars != null ? new EnvVars(extraEnvVars) : null;
 	}
 
 	@Override

--- a/src/main/resources/hudson/plugins/repo/RepoChangeLogSet/digest.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoChangeLogSet/digest.jelly
@@ -17,9 +17,16 @@
 		<ul>
 			<j:forEach var="cs" items="${it.items}" varStatus="loop">
 				<li>
-					<j:out value="${cs.msgAnnotated}"/> <br/>
-					-- <a href="${rootURL}/${cs.author.url}/">${cs.author}</a> /
-					<a href="changes#detail${loop.index}">detail</a> <br/>
+					<j:out value="${cs.msgAnnotated}"/> —
+					<j:choose>
+						<j:when test="${cs.authorName != null}">
+							<a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
+						</j:when>
+						<j:otherwise>
+							${cs.path}
+						</j:otherwise>
+					</j:choose>
+					/ <a href="changes#detail${loop.index}">detail</a> <br/>
 				</li>
 			</j:forEach>
 		</ul>

--- a/src/main/resources/hudson/plugins/repo/RepoChangeLogSet/index.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoChangeLogSet/index.jelly
@@ -21,14 +21,20 @@
 					<div class="changeset-message">
 						<b>
 						Project: ${cs.path}<br/>
-						Revision: ${cs.revision}<br/>
-						Author: <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
-							&amp;lt;${cs.authorEmail}&amp;gt; on ${cs.authorDate}<br/>
-						Committer: <a href="${rootURL}/${cs.committer.url}/">${cs.committer}</a>
-							&amp;lt;${cs.committerEmail}&amp;gt; on ${cs.committerDate}<br/>
-            			</b><br/>
+						<j:if test="${cs.revision != null}">
+						    Revision: ${cs.revision}<br/>
+						</j:if>
+						<j:if test="${cs.authorName != null}">
+							Author: <a href="${rootURL}/${cs.author.url}/">${cs.author}</a>
+								&amp;lt;${cs.authorEmail}&amp;gt; on ${cs.authorDate}<br/>
+						<j:if test="${cs.committer != null}">
+						</j:if>
+							Committer: <a href="${rootURL}/${cs.committer.url}/">${cs.committer}</a>
+								&amp;lt;${cs.committerEmail}&amp;gt; on ${cs.committerDate}<br/>
+						</j:if>
+						</b><br/>
 						<pre><st:out value="${cs.msg}"/></pre>
-						
+
 						<table>
 						<j:forEach var="item" items="${cs.modifiedFiles}">
 						    <tr>


### PR DESCRIPTION
A very strong limit to using from pipeline is that "contextual" environment variable (set during the job) cannot be accessed from the SCM [1]. To overcome this, this allow explicitely passing the environment variables from the checkout step.

It is now possible to use ssh agent or withEnv() block with repo checkout in Jenkins pipelines, like in the following code:

```groovy
sshAgent(['gerrit-ssh-credentials-id']) {
  checkout([$class: 'RepoScm', manifestRepositoryUrl: 'ssh://server/project',
            extraEnvVars: getContext(hudson.EnvVars)])
}
```

The pull request also includes a few minor changes:
* Fix crash when used from pipeline and changelog is empty.
* Include revision for new projects in changes view.
* In detailed view, hide missing fields: e.g. revision, author and commiter for new or removed projects.
* In compact view, show project name instead of 'unknown' author for new or removed projects.

[1]: https://issues.jenkins-ci.org/browse/JENKINS-37557