### PR TITLE
Add missing repo options; specifying platform, init --submodules and fetch --fetch-submodules, noTags and currentBranch

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -104,6 +104,8 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private boolean trace;
 	@CheckForNull private boolean showAllChanges;
 	@CheckForNull private boolean noTags;
+	@CheckForNull private boolean manifestSubmodules;
+	@CheckForNull private boolean fetchSubmodules;
 	@CheckForNull private Set<String> ignoreProjects;
 	@CheckForNull private EnvVars extraEnvVars;
 	@CheckForNull private boolean noCloneBundle;
@@ -298,6 +300,7 @@ public class RepoScm extends SCM implements Serializable {
 	public boolean isTrace() {
 		return trace;
 	}
+
 	/**
 	 * Returns the value of noTags.
 	 */
@@ -311,6 +314,21 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public boolean isNoCloneBundle() {
 		return noCloneBundle;
+	}
+
+	/**
+	 * Returns the value of manifestSubmodules.
+	 */
+	@Exported
+	public boolean isManifestSubmodules() {
+		return manifestSubmodules;
+	}
+
+	/**
+	 * Returns the value of fetchSubmodules.
+	 */
+	public boolean isFetchSubmodules() {
+		return fetchSubmodules;
 	}
 
 	/**
@@ -418,6 +436,8 @@ public class RepoScm extends SCM implements Serializable {
 		trace = false;
 		showAllChanges = false;
 		noTags = false;
+		manifestSubmodules = false;
+		fetchSubmodules = false;
 		ignoreProjects = Collections.<String>emptySet();
 		noCloneBundle = false;
 	}
@@ -643,6 +663,30 @@ public class RepoScm extends SCM implements Serializable {
 	}
 
 	/**
+	 * Set manifestSubmodules.
+	 *
+	 * @param manifestSubmodules
+	 *            If this value is true, add the "--submodules" option when
+	 *            executing "repo init".
+	 */
+	@DataBoundSetter
+	public void setManifestSubmodules(final boolean manifestSubmodules) {
+		this.manifestSubmodules = manifestSubmodules;
+	}
+
+	/**
+	 * Set fetchSubmodules.
+	 *
+	 * @param fetchSubmodules
+	 *            If this value is true, add the "--fetch-submodules" option when
+	 *            executing "repo sync".
+	 */
+	@DataBoundSetter
+	public void setFetchSubmodules(final boolean fetchSubmodules) {
+		this.fetchSubmodules = fetchSubmodules;
+	}
+
+	/**
 	 * Sets list of projects which changes will be ignored when
 	 * calculating whether job needs to be rebuild. This field corresponds
 	 * to serverpath i.e. "name" section of the manifest.
@@ -864,7 +908,9 @@ public class RepoScm extends SCM implements Serializable {
 		if (isNoCloneBundle()) {
 			commands.add("--no-clone-bundle");
 		}
-
+		if (fetchSubmodules) {
+			commands.add("--fetch-submodules");
+		}
 		return launcher.launch().stdout(logger).pwd(workspace)
                 .cmds(commands).envs(env).join();
 	}
@@ -909,6 +955,9 @@ public class RepoScm extends SCM implements Serializable {
 		}
 		if (isNoCloneBundle()) {
 			commands.add("--no-clone-bundle");
+		}
+		if (manifestSubmodules) {
+			commands.add("--submodules");
 		}
 		int returnCode =
 				launcher.launch().stdout(logger).pwd(workspace)

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -983,6 +983,12 @@ public class RepoScm extends SCM implements Serializable {
 		if (isNoCloneBundle()) {
 			commands.add("--no-clone-bundle");
 		}
+		if (currentBranch) {
+			commands.add("--current-branch");
+		}
+		if (noTags) {
+			commands.add("--no-tags");
+		}
 		if (manifestSubmodules) {
 			commands.add("--submodules");
 		}

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -89,6 +89,7 @@ public class RepoScm extends SCM implements Serializable {
 	// Advanced Fields:
 	@CheckForNull private String manifestFile;
 	@CheckForNull private String manifestGroup;
+	@CheckForNull private String manifestPlatform;
 	@CheckForNull private String repoUrl;
 	@CheckForNull private String mirrorDir;
 	@CheckForNull private String manifestBranch;
@@ -184,6 +185,15 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public String getManifestGroup() {
 		return manifestGroup;
+	}
+
+	/**
+	 * Returns the platform of projects to fetch. By default, this is null and
+	 * repo will automatically fetch the appropriate platform.
+	 */
+	@CheckForNull
+	public String getManifestPlatform() {
+		return manifestPlatform;
 	}
 
 	/**
@@ -478,6 +488,19 @@ public class RepoScm extends SCM implements Serializable {
 	@DataBoundSetter
 	public void setManifestGroup(@CheckForNull final String manifestGroup) {
 		this.manifestGroup = Util.fixEmptyAndTrim(manifestGroup);
+	}
+
+	/**
+	 * Set the platform of projects to fetch.
+	 *
+	 * @param manifestPlatform
+	 *        The platform for the projects that need to be fetched.
+	 *        Typically, this is null and only projects for the current platform
+	 *        will be fetched.
+	 */
+	@DataBoundSetter
+	public void setManifestPlatform(@CheckForNull final String manifestPlatform) {
+		this.manifestPlatform = manifestPlatform;
 	}
 
 	/**
@@ -949,6 +972,10 @@ public class RepoScm extends SCM implements Serializable {
 		if (manifestGroup != null) {
 			commands.add("-g");
 			commands.add(env.expand(manifestGroup));
+		}
+		if (manifestPlatform != null) {
+			commands.add("-p");
+			commands.add(env.expand(manifestPlatform));
 		}
 		if (depth != 0) {
 			commands.add("--depth=" + depth);

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -24,6 +24,10 @@
 		<f:entry title="Group" help="/plugin/repo/help-manifestGroup.html" field="manifestGroup">
 			<f:textbox/>
 		</f:entry>
+
+		<f:entry title="Platform" help="/plugin/repo/help-manifestPlatform.html" field="manifestPlatform">
+			<f:textbox/>
+		</f:entry>
 		
 		<f:entry title="IgnoreChanges" help="/plugin/repo/help-ignoreChanges.html" field="ignoreProjects">
 			<f:textarea rows="3" />

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -53,6 +53,14 @@
 			<f:checkbox default="true"/>
 		</f:entry>
 
+		<f:entry title="Sync manifest submodules" help="/plugin/repo/help-manifestSubmodules.html" field="manifestSubmodules">
+			<f:checkbox default="false"/>
+		</f:entry>
+
+		<f:entry title="Fetch submodules" help="/plugin/repo/help-fetchSubmodules.html" field="fetchSubmodules">
+			<f:checkbox default="false"/>
+		</f:entry>
+
 		<f:entry title="Reset first" help="/plugin/repo/help-resetFirst.html" field="resetFirst">
 			<f:checkbox/>
 		</f:entry>

--- a/src/main/webapp/help-currentBranch.html
+++ b/src/main/webapp/help-currentBranch.html
@@ -2,6 +2,6 @@
 	<p>
 	 Fetch only the current branch from server.
 	 Increases the speed of the repo sync operation.
-   This is passed to repo as <code>repo sync <i>-c</i></code>.
+   This is passed to repo as <code>repo init <i>--current-branch</i></code> and <code>repo sync <i>-c</i></code>.
   </p>
 </div>

--- a/src/main/webapp/help-fetchSubmodules.html
+++ b/src/main/webapp/help-fetchSubmodules.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Fetch submodules for from server.
+        This is passed to repo as <code>repo sync <i>--fetch-submodules</i></code>.
+    </p>
+</div>

--- a/src/main/webapp/help-manifestPlatform.html
+++ b/src/main/webapp/help-manifestPlatform.html
@@ -1,0 +1,8 @@
+<div>
+    <p>
+        Restrict manifest projects to ones with a specified platform group <code>[auto|all|none|linux|darwin|...]</code>
+        This is passed to repo as <code>repo init -P <i>platformName</i></code>. If a platform is not provided, the
+        <code>-p</code> option is not passed to repo and it will default to <code>auto</code> and ony fetch projects
+        which needed for current system.
+    </p>
+</div>

--- a/src/main/webapp/help-manifestSubmodules.html
+++ b/src/main/webapp/help-manifestSubmodules.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Sync any submodules associated with the manifest repo.
+        This is passed to repo as <code>repo init <i>--submodules</i></code>.
+    </p>
+</div>

--- a/src/main/webapp/help-noTags.html
+++ b/src/main/webapp/help-noTags.html
@@ -1,6 +1,6 @@
 <div>
    <p>
    Don't fetch tags.
-   This is passed to repo as <code>repo sync <i>--no-tags</i></code>.
+   This is passed to repo as <code>repo init <i>--no-tags</i></code> and <code>repo sync <i>--no-tags</i></code>.
   </p>
 </div>


### PR DESCRIPTION
Support some missing repo flags/options:
* Allow specifying platform in `repo init`
* Allow handling submodules (`repo init --submodules` and `repo fetch --fetch-submodules`)
* Apply `noTags` and `currentBranch` to repo init as well