### PR TITLE
Add support for repo-branch

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -91,6 +91,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private String manifestGroup;
 	@CheckForNull private String manifestPlatform;
 	@CheckForNull private String repoUrl;
+	@CheckForNull private String repoBranch;
 	@CheckForNull private String mirrorDir;
 	@CheckForNull private String manifestBranch;
 	@CheckForNull private int jobs;
@@ -203,6 +204,15 @@ public class RepoScm extends SCM implements Serializable {
 	@Exported
 	public String getRepoUrl() {
 		return repoUrl;
+	}
+
+	/**
+	 * Returns the repo branch. by default, this is null and
+	 * repo is used from the default branch
+	 */
+	@Exported
+	public String getRepoBranch() {
+		return repoBranch;
 	}
 
 	/**
@@ -376,7 +386,7 @@ public class RepoScm extends SCM implements Serializable {
 	 * @param destinationDir        If not null then the source is synced to the destinationDir
 	 *                              subdirectory of the workspace.
 	 * @param repoUrl               If not null then use this url as repo base,
-	 *                              instead of the default
+	 *                              instead of the default.
 	 * @param currentBranch         If this value is true, add the "-c" option when executing
 	 *                              "repo sync".
 	 * @param resetFirst            If this value is true, do "repo forall -c 'git reset --hard'"
@@ -432,6 +442,7 @@ public class RepoScm extends SCM implements Serializable {
 		manifestFile = null;
 		manifestGroup = null;
 		repoUrl = null;
+		repoBranch = null;
 		mirrorDir = null;
 		manifestBranch = null;
 		jobs = 0;
@@ -660,6 +671,18 @@ public class RepoScm extends SCM implements Serializable {
 	@DataBoundSetter
 	public void setRepoUrl(@CheckForNull final String repoUrl) {
 		this.repoUrl = Util.fixEmptyAndTrim(repoUrl);
+	}
+
+	/**
+	 * Set the repo branch.
+	 *
+	 * @param repoBranch
+	 *        If not null then use this as branch for repo itself
+	 *        instead of the default.
+	 */
+	@DataBoundSetter
+	public void setRepoBranch(@CheckForNull final String repoBranch) {
+		this.repoBranch = Util.fixEmptyAndTrim(repoBranch);
 	}
 
 	/**
@@ -968,6 +991,9 @@ public class RepoScm extends SCM implements Serializable {
 		if (repoUrl != null) {
 			commands.add("--repo-url=" + env.expand(repoUrl));
 			commands.add("--no-repo-verify");
+		}
+		if (repoBranch != null) {
+			commands.add("--repo-branch=" + env.expand(repoBranch));
 		}
 		if (manifestGroup != null) {
 			commands.add("-g");

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -41,6 +41,10 @@
 			<f:textbox/>
 		</f:entry>
 
+		<f:entry title="Repo Branch" help="/plugin/repo/help-repoBranch.html" field="repoBranch">
+		    <f:textbox/>
+		</f:entry>
+
 		<f:entry title="Mirror Directory" help="/plugin/repo/help-mirrorDir.html" field="mirrorDir">
 			<f:textbox/>
 		</f:entry>

--- a/src/main/webapp/help-repoBranch.html
+++ b/src/main/webapp/help-repoBranch.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Use a specific branch for pulling repo itself. By default this is empty, and repo will be using its
+        default branch (i.e. stable)
+    </p>
+</div>


### PR DESCRIPTION
With python3 arriving at repo, google introduced the repo-1 or maint branch to not break old installations. This commit facilitates this.