### PR TITLE
Multiple checkout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>repo</artifactId>
-  <version>1.13.1-SNAPSHOT</version>
+  <version>1.13.2</version>
   <packaging>hpi</packaging>
   <name>Jenkins REPO plugin</name>
   <description>Integrates Jenkins with REPO SCM</description>

--- a/src/main/java/hudson/plugins/repo/ManifestAction.java
+++ b/src/main/java/hudson/plugins/repo/ManifestAction.java
@@ -47,6 +47,7 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	private static final long serialVersionUID = 1;
 
 	private transient Run<?, ?> run;
+	private transient RevisionState revisionState;
 
 	/**
 	 * Allow disambiguation of the action url when multiple {@link RevisionState} actions present.
@@ -70,6 +71,16 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	 */
 	public void setIndex(final Integer index) {
 		this.index = index == null || index <= 1 ? null : index;
+		try {
+			final int i = index == null ? 0 : index - 1;
+			final List<RevisionState> revisionStates = run.getActions(RevisionState.class);
+			if (revisionStates.size() > i && i >= 0) {
+				revisionState = revisionStates.get(i);
+			}
+		} catch (Exception e) {
+			debug.log(Level.WARNING, "Error getting revision state {0}", e.getMessage());
+			revisionState = null;
+		}
 	}
 
 	/**
@@ -125,16 +136,27 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	 * Gets a String representation of the static manifest for this repo snapshot.
 	 */
 	public String getManifest() {
-		String result = "";
-		try {
-			final int i = index == null ? 0 : index - 1;
-			final List<RevisionState> revisionStates = run.getActions(RevisionState.class);
-			if (revisionStates.size() > i && i >= 0) {
-				result = revisionStates.get(i).getManifest();
-			}
-		} catch (Exception e) {
-			debug.log(Level.WARNING, "Error getting revision state {0}", e.getMessage());
-		}
-		return result;
+		return revisionState == null ? "" : revisionState.getManifest();
+	}
+
+	/**
+	 * Returns the manifest repository's url for this repo snapshot.
+	 */
+	public String getUrl() {
+		return revisionState == null ? "" : revisionState.getUrl();
+	}
+
+	/**
+	 * Returns the manifest repository's branch name for this repo snapshot.
+	 */
+	public String getBranch() {
+		return revisionState == null ? "" : revisionState.getBranch();
+	}
+
+	/**
+	 * Returns the path to the manifest file for this repo snapshot.
+	 */
+	public String getFile() {
+		return revisionState == null ? "" : revisionState.getFile();
 	}
 }

--- a/src/main/java/hudson/plugins/repo/ManifestAction.java
+++ b/src/main/java/hudson/plugins/repo/ManifestAction.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.repo;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -40,10 +41,10 @@ import javax.annotation.CheckForNull;
  * to recreate the exact state of the repository when the build was run.
  */
 @ExportedBean(defaultVisibility = 999)
-public class ManifestAction implements RunAction2, BuildBadgeAction  {
-
+public class ManifestAction implements RunAction2, Serializable, BuildBadgeAction {
 	private static Logger debug = Logger
 		.getLogger("hudson.plugins.repo.ManifestAction");
+	private static final long serialVersionUID = 1;
 
 	private transient Run<?, ?> run;
 
@@ -126,9 +127,9 @@ public class ManifestAction implements RunAction2, BuildBadgeAction  {
 	public String getManifest() {
 		String result = "";
 		try {
-			final int i = index == null ? 0 : index;
+			final int i = index == null ? 0 : index - 1;
 			final List<RevisionState> revisionStates = run.getActions(RevisionState.class);
-			if (revisionStates.size() >= i) {
+			if (revisionStates.size() > i && i >= 0) {
 				result = revisionStates.get(i).getManifest();
 			}
 		} catch (Exception e) {

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -895,7 +895,11 @@ public class RepoScm extends SCM implements Serializable {
 					repoDir,
 					showAllChanges);
 		}
-		build.addAction(new ManifestAction(build));
+
+		ManifestAction manifestAction = new ManifestAction(build);
+		int revisionStateCount = build.getActions(RevisionState.class).size();
+		manifestAction.setIndex(revisionStateCount);
+		build.addAction(manifestAction);
 	}
 
 	private int doSync(final Launcher launcher, @Nonnull final FilePath workspace,

--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -886,7 +886,6 @@ public class RepoScm extends SCM implements Serializable {
 		final RevisionState currentState =
 				new RevisionState(manifest, manifestRevision, expandedUrl,
                         expandedBranch, expandedFile, listener.getLogger());
-		// TODO: check if already present...
 		build.addAction(currentState);
 
 		final Run previousBuild = build.getPreviousBuild();
@@ -903,6 +902,7 @@ public class RepoScm extends SCM implements Serializable {
 					showAllChanges);
 		}
 
+		// TODO: create a single action displaying all manifests?
 		ManifestAction manifestAction = new ManifestAction(build);
 		int revisionStateCount = build.getActions(RevisionState.class).size();
 		manifestAction.setIndex(revisionStateCount);

--- a/src/main/java/hudson/plugins/repo/RevisionState.java
+++ b/src/main/java/hudson/plugins/repo/RevisionState.java
@@ -55,7 +55,9 @@ class RevisionState extends SCMRevisionState implements Serializable {
 	private final String manifest;
 	private final Map<String, ProjectState> projects =
 			new TreeMap<String, ProjectState>();
+	private final String url;
 	private final String branch;
+	private final String file;
 
 	private static Logger debug =
 		Logger.getLogger("hudson.plugins.repo.RevisionState");
@@ -67,15 +69,22 @@ class RevisionState extends SCMRevisionState implements Serializable {
 	 *            A string representation of the static manifest XML file
 	 * @param manifestRevision
      *            Git hash of the manifest repo
+	 * @param url
+	 *            The URL of the manifest
 	 * @param branch
 	 *            The branch of the manifest project
+	 * @param file
+	 *            The path to the manifest file
 	 * @param logger
 	 *            A PrintStream for logging errors
 	 */
 	RevisionState(final String manifest, final String manifestRevision,
-				  final String branch, @Nullable final PrintStream logger) {
+				  final String url, final String branch, final String file,
+				  @Nullable final PrintStream logger) {
 		this.manifest = manifest;
+		this.url = url;
 		this.branch = branch;
+		this.file = file;
 		try {
 			final InputSource xmlSource = new InputSource();
 			xmlSource.setCharacterStream(new StringReader(manifest));
@@ -151,8 +160,18 @@ class RevisionState extends SCMRevisionState implements Serializable {
 	@Override
 	public int hashCode() {
 		return (branch != null ? branch.hashCode() : 0)
+			^ (url != null ? url.hashCode() : 0)
+			^ (file != null ? file.hashCode() : 0)
 			^ (manifest != null ? manifest.hashCode() : 0)
 			^ projects.hashCode();
+	}
+
+	/**
+	 * Returns the manifest repository's url when this state was
+	 * created.
+	 */
+	public String getUrl() {
+		return url;
 	}
 
 	/**
@@ -161,6 +180,13 @@ class RevisionState extends SCMRevisionState implements Serializable {
 	 */
 	public String getBranch() {
 		return branch;
+	}
+
+	/**
+	 * Returns the path to the manifest file used when this state was created.
+	 */
+	public String getFile() {
+		return file;
 	}
 
 	/**

--- a/src/main/resources/hudson/plugins/repo/ManifestAction/index.jelly
+++ b/src/main/resources/hudson/plugins/repo/ManifestAction/index.jelly
@@ -16,6 +16,8 @@
 			To recreate this build, copy the below manifest and past it to .repo/manifest.xml, then run 'repo sync'.
 			When done, be sure to undo changes to the .repo/manifest.xml file and repo sync again.
 			<br/><br/>
+			Generated from <tt>${it.file}</tt> in branch <tt>${it.branch}</tt> of <tt>${it.url}</tt>.
+			<br/><br/>
 			Manifest File:<br/><br/>
 			<textarea rows="15" cols="140">${it.manifest}</textarea>
 		</l:main-panel>

--- a/src/test/java/hudson/plugins/repo/TestRevisionState.java
+++ b/src/test/java/hudson/plugins/repo/TestRevisionState.java
@@ -74,12 +74,12 @@ public class TestRevisionState extends TestCase {
 	protected void setUp() throws Exception {
 		super.setUp();
 
-		stateOne = new RevisionState(manifestOne,     "a",  "master", null);
-		stateOneCopy = new RevisionState(manifestOne, "a",  "master", null);
-		stateTwo = new RevisionState(manifestTwo,     "a",  "master", null);
-		stateThree = new RevisionState(manifestThree, "a",  "master", null);
+		stateOne = new RevisionState(manifestOne,     "a",  "https://my.gerrit.com/myrepo", "master", "default.xml", null);
+		stateOneCopy = new RevisionState(manifestOne, "a",  "https://my.gerrit.com/myrepo", "master", "default.xml", null);
+		stateTwo = new RevisionState(manifestTwo,     "a",  "https://my.gerrit.com/myrepo", "master", "default.xml", null);
+		stateThree = new RevisionState(manifestThree, "a",  "https://my.gerrit.com/myrepo", "master", "default.xml", null);
 
-		stateMChange = new RevisionState(manifestThree, "b",  "master", null);
+		stateMChange = new RevisionState(manifestThree, "b",  "https://my.gerrit.com/myrepo", "master", "default.xml", null);
 	}
 
 	/**


### PR DESCRIPTION
Better handle performing multiple checkouts from the same build:
* Match manifest url/branch/file to compute changes
* Store extra index in ManifestAction to display each manifest
* Display the manifest url/branch/file in manifest action