### PR TITLE
Remove unneeded configuration from buildPlugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(platforms: ['linux'], findbugs: [run: true, archive:true, unstableTotalAll: '0'], checkstyle: [run: true, archive:true, unstableTotalAll: '0'])
+buildPlugin(platforms: ['linux'])


### PR DESCRIPTION
Checkstyle and spotbugs are being enabled by default in https://github.com/jenkins-infra/pipeline-library/pull/121, (assuming that checkstyle is bound to a phase in the build directly, the task is no longer directly invoked)