### PR TITLE
Add option to enable --worktree option to repo init

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -111,6 +111,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private Set<String> ignoreProjects;
 	@CheckForNull private EnvVars extraEnvVars;
 	@CheckForNull private boolean noCloneBundle;
+	@CheckForNull private boolean worktree;
 
 	/**
 	 * Returns the manifest repository URL.
@@ -335,6 +336,13 @@ public class RepoScm extends SCM implements Serializable {
 	public boolean isNoCloneBundle() {
 		return noCloneBundle;
 	}
+	/**
+	 * Returns the value of isWorktree.
+	 */
+	@Exported
+	public boolean isWorktree() {
+		return worktree;
+	}
 
 	/**
 	 * Returns the value of manifestSubmodules.
@@ -428,6 +436,7 @@ public class RepoScm extends SCM implements Serializable {
 		setShowAllChanges(showAllChanges);
 		setRepoUrl(repoUrl);
 		ignoreProjects = Collections.<String>emptySet();
+		setWorktree(false);
 	}
 
 	/**
@@ -461,6 +470,7 @@ public class RepoScm extends SCM implements Serializable {
 		fetchSubmodules = false;
 		ignoreProjects = Collections.<String>emptySet();
 		noCloneBundle = false;
+		worktree = false;
 	}
 
 	/**
@@ -659,6 +669,18 @@ public class RepoScm extends SCM implements Serializable {
 	@DataBoundSetter
 	public void setNoCloneBundle(final boolean noCloneBundle) {
 		this.noCloneBundle = noCloneBundle;
+	}
+
+	/**
+	 * Set worktree.
+	 *
+	 * @param worktree
+	 *        If this value is true, add the "--worktree" option when
+	 *        running the "repo init" command.
+     */
+	@DataBoundSetter
+	public void setWorktree(final boolean worktree) {
+		this.worktree = worktree;
 	}
 
 	/**
@@ -1019,6 +1041,9 @@ public class RepoScm extends SCM implements Serializable {
 		}
 		if (isNoCloneBundle()) {
 			commands.add("--no-clone-bundle");
+		}
+		if (isWorktree()) {
+			commands.add("--worktree");
 		}
 		if (currentBranch) {
 			commands.add("--current-branch");

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -104,5 +104,9 @@
 			<f:checkbox/>
 		</f:entry>
 
+		<f:entry title="Worktree" help="/plugin/repo/help-worktree.html" field="worktree">
+			<f:checkbox/>
+		</f:entry>
+
 	</f:advanced>
 </j:jelly>

--- a/src/main/webapp/help-worktree.html
+++ b/src/main/webapp/help-worktree.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Use `git worktree` for checkouts (At least, Git version 2.15 is required to avoid dangerous gc bugs). Usefull under Windows because it no longer require symlinks at all.
+    </p>
+</div>

--- a/src/test/java/hudson/plugins/repo/TestRepoScm.java
+++ b/src/test/java/hudson/plugins/repo/TestRepoScm.java
@@ -64,4 +64,11 @@ public class TestRepoScm extends TestCase {
 		scm.setCleanFirst(true);
 		assertEquals(true, scm.isCleanFirst());
 	}
+
+	public void testWorktree() {
+		RepoScm scm = new RepoScm("http://manifesturl");
+		assertEquals(false, scm.isWorktree());
+		scm.setWorktree(true);
+		assertEquals(true, scm.isWorktree());
+	}
 }


### PR DESCRIPTION
The "worktree" option is absolutely necessary under Windows to not use symlink which requires administration rights. 