### PR TITLE
Add the manifest file name in display name

### DIFF
--- a/src/main/java/hudson/plugins/repo/ManifestAction.java
+++ b/src/main/java/hudson/plugins/repo/ManifestAction.java
@@ -122,7 +122,7 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	 * Returns the display name to use for the action.
 	 */
 	public String getDisplayName() {
-		return "Repo Manifest";
+		return "Repo Manifest ’" + getFile() + "’";
 	}
 
 	/**


### PR DESCRIPTION
When several manifests are checkout in the same job, it avoids
showing several identical "Repo Manifest" entry in the left menu.