### PR TITLE
Parse username in email address

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLogEntry.java
@@ -29,6 +29,7 @@ import hudson.scm.EditType;
 import hudson.scm.ChangeLogSet.AffectedFile;
 
 import java.util.AbstractList;
+import java.util.Collections;
 import java.util.Collection;
 import java.util.List;
 
@@ -252,7 +253,20 @@ public class ChangeLogEntry extends ChangeLogSet.Entry {
 		if (authorName == null) {
 			return User.getUnknown();
 		}
-		return User.get(authorEmail);
+
+		// get user using the full email address
+		User user = User.get(authorEmail, false, Collections.emptyMap());
+		if (user == null) {
+			// get user using the account name in the email address
+			String[] emailParts = authorEmail.split("@");
+			if (emailParts.length > 0) {
+				user = User.get(emailParts[0], true, Collections.emptyMap());
+			} else {
+				user = User.getUnknown();
+			}
+		}
+		return user;
+
 	}
 
 	@Override


### PR DESCRIPTION
Similar to Git Plugin, getAuthor() should try to parse user using the name in the email address if the user is not found.
For example, if "chowmanchun@realtek-sg.com" cannot be found in the user database, we should try "chowmanchun" from the email address "chowmanchun@realtek-sg.com".

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
