### PR TITLE
Fix "checkout" when previous build has a bad local manifest and "worktree" option is set

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,13 +9,15 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>repo</artifactId>
-  <version>1.14.1-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Jenkins REPO plugin</name>
   <description>Integrates Jenkins with REPO SCM</description>
   <url>https://github.com/jenkinsci/repo-plugin/blob/master/doc/README.adoc</url>
 
   <properties>
+    <revision>1.14.1</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.53</version>
+    <version>3.56</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Cleanup local manifest from a previous build before initializing workspace. This fix "checkout" when previous build has a bad local manifest and "worktree" option is set

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue