### PR TITLE
[JENKINS-64150] Fix blank manifest view

### DIFF
--- a/src/main/java/hudson/plugins/repo/ManifestAction.java
+++ b/src/main/java/hudson/plugins/repo/ManifestAction.java
@@ -47,7 +47,7 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	private static final long serialVersionUID = 1;
 
 	private transient Run<?, ?> run;
-	private transient RevisionState revisionState;
+	private RevisionState revisionState;
 
 	/**
 	 * Allow disambiguation of the action url when multiple {@link RevisionState} actions present.

--- a/src/main/java/hudson/plugins/repo/ManifestAction.java
+++ b/src/main/java/hudson/plugins/repo/ManifestAction.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import hudson.model.BuildBadgeAction;
@@ -69,6 +70,7 @@ public class ManifestAction implements RunAction2, Serializable, BuildBadgeActio
 	 *
 	 * @param index the index, indexes less than or equal to {@code 1} will be discarded.
 	 */
+	@DataBoundSetter
 	public void setIndex(final Integer index) {
 		this.index = index == null || index <= 1 ? null : index;
 		try {


### PR DESCRIPTION
As describe on https://github.com/jenkinsci/repo-plugin/pull/75 and on [JENKINS-64150](https://issues.jenkins.io/browse/JENKINS-64150), the repo manifest informations are blanked on existing jobs after restart of Jenkins server on release 1.14.0. It is related to changes made on https://github.com/jenkinsci/repo-plugin/pull/62. 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue