### PR TITLE
Fix default parameters value resolution.

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -47,9 +47,10 @@ import hudson.Launcher;
 import hudson.Util;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Run;
-import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import hudson.model.TaskListener;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
@@ -147,12 +148,11 @@ public class RepoScm extends SCM implements Serializable {
 		if (params != null) {
 			for (ParameterDefinition param
 					: params.getParameterDefinitions()) {
-				if (param instanceof StringParameterDefinition) {
-					final StringParameterDefinition stpd =
-						(StringParameterDefinition) param;
-					final String dflt = stpd.getDefaultValue();
-					if (dflt != null) {
-						finalEnv.put(param.getName(), dflt);
+				ParameterValue defaultParamValue = param.getDefaultParameterValue();
+				if (defaultParamValue instanceof StringParameterValue) {
+					final StringParameterValue spv = (StringParameterValue) defaultParamValue;
+					if (spv.getValue() != null) {
+						finalEnv.put(param.getName(), spv.toString());
 					}
 				}
 			}


### PR DESCRIPTION
Not all custom parameter definitions can be inherited from StringParameterDefinition, but have default String value. 
For example [ExtendedChoiceParameter](https://github.com/jenkinsci/extended-choice-parameter-plugin): 
> https://github.com/jenkinsci/extended-choice-parameter-plugin/blob/master/src/main/java/com/cwctravel/hudson/plugins/extended_choice_parameter/ExtendedChoiceParameterDefinition.java

It cannot inherit from _StringParameterDefinition_, since the method createValue(StaplerRequest req) is final in [SimpleParameterDefinition.class](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/SimpleParameterDefinition.java#L34)

This commit fix default parameters value resolution and makes it dependent on default ParameterValue instead of ParameterDefinition.