### PR TITLE
Fix broken jenkins plugin documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
   <name>Jenkins REPO plugin</name>
   <description>Integrates Jenkins with REPO SCM</description>
-  <url>https://github.com/jenkinsci/repo-plugin/blob/master/doc/README.adoc</url>
+  <url>https://github.com/jenkinsci/repo-plugin/blob/master/README.adoc</url>
 
   <properties>
     <revision>1.14.1</revision>


### PR DESCRIPTION
Update made on PR https://github.com/jenkinsci/repo-plugin/pull/74 broke https://plugins.jenkins.io/repo/ because line below was not updated https://github.com/jenkinsci/repo-plugin/blob/729f5c57bf4cd8fe31f6502c90854ba0f24de464/pom.xml#L16.

Thanks to @daniel-beck for reporting this isssue

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue