### PR TITLE
[JENKINS-68562] Fix Repo checkouts on the built-in node for Windows controllers

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -950,15 +951,27 @@ public class RepoScm extends SCM implements Serializable {
 		build.addAction(manifestAction);
 	}
 
-	private void abortIfUrlLocal() throws AbortException {
-		if (StringUtils.isNotEmpty(manifestRepositoryUrl)
-				&& (manifestRepositoryUrl.toLowerCase(Locale.ENGLISH).startsWith("file://")
-				|| Files.exists(Paths.get(manifestRepositoryUrl)))) {
+	void abortIfUrlLocal() throws AbortException {
+		if (!isValidRepositoryUrl(manifestRepositoryUrl)) {
 			throw new AbortException("Checkout of Repo url '" + manifestRepositoryUrl
 					+ "' aborted because it references a local directory, "
 					+ "which may be insecure. "
 					+ "You can allow local checkouts anyway by setting the system property '"
 					+ ALLOW_LOCAL_CHECKOUT_PROPERTY + "' to true.");
+		}
+	}
+
+	private static boolean isValidRepositoryUrl(String url) {
+		if (StringUtils.isEmpty(url)) {
+			return true;
+		} else if (url.toLowerCase(Locale.ENGLISH).startsWith("file://")) {
+			return false;
+		}
+		try {
+			// Check for local URLs with no protocol like /path/to/repo
+			return !Files.exists(Paths.get(url));
+		} catch (InvalidPathException e) {
+			return true;
 		}
 	}
 

--- a/src/test/java/hudson/plugins/repo/RepoScmTest.java
+++ b/src/test/java/hudson/plugins/repo/RepoScmTest.java
@@ -1,13 +1,16 @@
 package hudson.plugins.repo;
 
+import hudson.AbortException;
 import hudson.model.FreeStyleProject;
 import hudson.tasks.Shell;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * {@link JenkinsRule} based tests for {@link RepoScm}
@@ -30,5 +33,16 @@ public class RepoScmTest {
         scm = (RepoScm) project.getScm();
         assertTrue(scm.isCleanFirst());
         assertEquals(manifestRepositoryUrl, scm.getManifestRepositoryUrl());
+    }
+
+    @Issue("JENKINS-68562")
+    @Test
+    public void abortIfUrlLocal() throws Exception {
+        final String manifestRepositoryUrl = "https://gerrit/projects/platform.git";
+        try {
+            new RepoScm(manifestRepositoryUrl).abortIfUrlLocal();
+        } catch (AbortException e) {
+            fail("https manifest URLs should always be valid");
+        }
     }
 }


### PR DESCRIPTION
See [JENKINS-68562](https://issues.jenkins.io/browse/JENKINS-68562), which was filed against Git, but the same issue should apply here.

On Windows, `Paths.get` throws `InvalidPathException` for URL-like values such as `https://whatever`. This breaks the fixes for SECURITY-2478 in 55904fbb8c9d3e0b36fc26330374904cb68e8758 for Jenkins controllers running on Windows that perform checkouts on the built-in node.

CC @Pldi23 @rsandell 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
