### PR TITLE
Add static manifest into environment variables when we can.

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -85,6 +85,11 @@ import javax.annotation.Nullable;
 @ExportedBean
 public class RepoScm extends SCM implements Serializable {
 
+	/**
+	 * maximum length of string passed to a single environment variable.
+	 */
+	private static final int MAX_ARG_STRLEN = 131072;
+
 	private static Logger debug = Logger
 			.getLogger("hudson.plugins.repo.RepoScm");
 
@@ -1191,7 +1196,11 @@ public class RepoScm extends SCM implements Serializable {
 			env.put("REPO_MANIFEST_URL", ((RevisionState) state).getUrl());
 			env.put("REPO_MANIFEST_BRANCH", ((RevisionState) state).getBranch());
 			env.put("REPO_MANIFEST_FILE", ((RevisionState) state).getFile());
-			env.put("REPO_MANIFEST_XML", ((RevisionState) state).getManifest());
+			String manifest = ((RevisionState) state).getManifest();
+			if (manifest.length() > MAX_ARG_STRLEN) {
+				manifest = "_";
+			}
+			env.put("REPO_MANIFEST_XML", manifest);
 		}
 	}
 

--- a/src/main/resources/hudson/plugins/repo/RepoScm/buildEnv.properties
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/buildEnv.properties
@@ -1,4 +1,5 @@
 REPO_MANIFEST_URL.blurb=The URL of manifest repository used.
 REPO_MANIFEST_BRANCH.blurb=The branch of the manifest repository used.
 REPO_MANIFEST_FILE.blurb=The manifest filename used.
-REPO_MANIFEST_XML.blurb=The static manifest (in XML format).
+REPO_MANIFEST_XML.blurb=The static manifest (in XML format), if manifest size is greater \
+  than MAX_ARG_STRLEN (131072 bytes), value will be set to a single underscore character.


### PR DESCRIPTION
The value of an environment variable can't be greater than MAX_ARG_STRLEN, which is PAGE_SIZE * 32, aka 131072 bytes.