### PR TITLE
Pass no-repo-verify also to repo sync if needed

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -1030,6 +1030,12 @@ public class RepoScm extends SCM implements Serializable {
 		if (fetchSubmodules) {
 			commands.add("--fetch-submodules");
 		}
+		if (repoUrl != null) {
+			// When repoUrl is set, we allow for unsigned repo tool
+			// versions; so --no-repo-verify must be set both in init
+			// and sync.
+			commands.add("--no-repo-verify");
+		}
 		return launcher.launch().stdout(logger).pwd(workspace)
                 .cmds(commands).envs(env).join();
 	}


### PR DESCRIPTION
When a custom repo version is used (repoUrl parameter), `repo init` is called with --repo-url=* and --no-repo-verify, to allow for unsigned versions of the repo tool. `repo sync` does `repo selfupdate` automatically; so it also needs the --no-repo-verify parameter. Currently, `repo sync` ends up reverting back to the last signed release tag, which is inconsistent with `repo init` allowing unsigned versions.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue