### PR TITLE
Add support for --git-lfs on repo init

### DIFF
--- a/src/main/java/hudson/plugins/repo/RepoScm.java
+++ b/src/main/java/hudson/plugins/repo/RepoScm.java
@@ -128,6 +128,7 @@ public class RepoScm extends SCM implements Serializable {
 	@CheckForNull private boolean noTags;
 	@CheckForNull private boolean manifestSubmodules;
 	@CheckForNull private boolean fetchSubmodules;
+	@CheckForNull private boolean gitLfs;
 	@CheckForNull private Set<String> ignoreProjects;
 	@CheckForNull private EnvVars extraEnvVars;
 	@CheckForNull private boolean noCloneBundle;
@@ -380,6 +381,13 @@ public class RepoScm extends SCM implements Serializable {
 	}
 
 	/**
+	 * Returns the value of gitLfs.
+	 */
+	public boolean isGitLfs() {
+		return gitLfs;
+	}
+
+	/**
 	 * Returns the value of extraEnvVars.
 	 */
 	@Exported
@@ -488,6 +496,7 @@ public class RepoScm extends SCM implements Serializable {
 		noTags = false;
 		manifestSubmodules = false;
 		fetchSubmodules = false;
+		gitLfs = false;
 		ignoreProjects = Collections.<String>emptySet();
 		noCloneBundle = false;
 		worktree = false;
@@ -772,6 +781,18 @@ public class RepoScm extends SCM implements Serializable {
 	@DataBoundSetter
 	public void setFetchSubmodules(final boolean fetchSubmodules) {
 		this.fetchSubmodules = fetchSubmodules;
+	}
+
+	/**
+	 * Set gitLfs.
+	 *
+	 * @param gitLfs
+	 *            If this value is true, add the "--git-lfs" option when
+	 *            executing "repo init".
+	 */
+	@DataBoundSetter
+	public void setGitLfs(final boolean gitLfs) {
+		this.gitLfs = gitLfs;
 	}
 
 	/**
@@ -1060,6 +1081,9 @@ public class RepoScm extends SCM implements Serializable {
 		    commands.add("--trace");
 		}
 		commands.add("init");
+		if (isGitLfs()) {
+			commands.add("--git-lfs");
+		}
 		commands.add("-u");
 		commands.add(env.expand(manifestRepositoryUrl));
 		if (manifestBranch != null) {

--- a/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/config.jelly
@@ -69,6 +69,10 @@
 			<f:checkbox default="false"/>
 		</f:entry>
 
+		<f:entry title="GIT large file storage" field="gitLfs">
+			<f:checkbox default="false"/>
+		</f:entry>
+
 		<f:entry title="Reset first" field="resetFirst">
 			<f:checkbox/>
 		</f:entry>

--- a/src/main/resources/hudson/plugins/repo/RepoScm/help-gitLfs.html
+++ b/src/main/resources/hudson/plugins/repo/RepoScm/help-gitLfs.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+      Enable git lfs.  This is passed to repo as repo init --git-lfs.
+    </p>
+</div>


### PR DESCRIPTION
 Add 'GIT large file storage' option in Advanced settings.   Enabling the option passes --git-lfs to repo init command.  Currently, using the repo plug-in with LFS enabled git repositories causes repo sync to only pull the git reference file for the LFS stored files.  Passing --git-lfs to repo init resolves this issue. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
