### PR TITLE
Set log level to FINEST

### DIFF
--- a/src/main/java/hudson/plugins/repo/ChangeLog.java
+++ b/src/main/java/hudson/plugins/repo/ChangeLog.java
@@ -182,7 +182,7 @@ class ChangeLog extends ChangeLogParser {
             final String o = new String(gitOutput.toByteArray(), Charset.defaultCharset());
 			final String[] changelogs = o.split(
                             "\\[\\[<as7d9m1R_MARK_A>\\]\\]");
-            debug.log(Level.INFO, o);
+            debug.log(Level.FINEST, o);
 			for (final String changelog : changelogs) {
                 final String[] parts = changelog.split(
                         "\\[\\[<as7d9m1R_MARK_B>\\]");


### PR DESCRIPTION
All log calls in `generateChangelog(..)` call `debug.log(Level.FINEST,...);` but not in this case.
This is flooding the Jenkins System Log in case of larger REPO manifest.xml files.

From my point of view everything should be set to `Level.FINEST` and one can enable a dedicated Log for this particular class.

### Testing done
(no tests done just decrease log level)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
